### PR TITLE
feat: Phase 2 — Kontakte & Karte

### DIFF
--- a/MeshCoreMac.xcodeproj/project.pbxproj
+++ b/MeshCoreMac.xcodeproj/project.pbxproj
@@ -7,39 +7,46 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C098BCE92A76BF310CB1AF3 /* ContactStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3857B6E683FD02DE91A5D77 /* ContactStoreTests.swift */; };
 		0E617710ECB95FE7AC5FAF49 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B647C2A265D4FE03D49FFAAC /* NotificationService.swift */; };
 		16CCE33A639DBCBAA7940DAA /* MeshCoreMacTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 183805CD72006F83823BFC87 /* MeshCoreMacTests.swift */; };
 		1AEE1922B696E865C7105755 /* MessageStoreRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F1C8E34ED7877138EE8DFD /* MessageStoreRecord.swift */; };
 		25BFD0400337844A44EABC45 /* MainWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 393807736FFBD890E13612F1 /* MainWindowView.swift */; };
 		2D7CB194243320D0528434A1 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407C25969742DD6C873C36BF /* ChatView.swift */; };
+		3CC3F1C10E6762928FBEDDF1 /* ContactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE099058ECAA1C500D088343 /* ContactDetailView.swift */; };
 		448C88E05CE4B31F44934165 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0758B0FE289EF74EC6DA0563 /* ConnectionState.swift */; };
 		497B9FA1A2C2855CD6B81DAE /* MeshCoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7662F98A87064732146A9E28 /* MeshCoreProtocol.swift */; };
 		4A9362842023A58F1E2120A0 /* MeshMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE82B0467AA0889350B7F71 /* MeshMessageTests.swift */; };
 		4FC0F78991F6699AF141F6F6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E3B2AAA9D808D2D8F4E36A3 /* AppDelegate.swift */; };
 		52354C51ADAF63656EE518FC /* BluetoothServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB1294F545A99E8FF503052 /* BluetoothServiceProtocol.swift */; };
 		5B7087A53374ADC39A994499 /* MessageStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36286B542A2D72477F42748F /* MessageStoreTests.swift */; };
+		605F5416EE031A40776F65DF /* ContactsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D987A40EB870F66E60EC56 /* ContactsViewModelTests.swift */; };
 		61A84A02A228C2AACF690437 /* MeshCoreProtocolServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40EF55C96200FE31C411F79A /* MeshCoreProtocolServiceTests.swift */; };
 		6A1D9AF51D03ECFC4F90028C /* ErrorBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6C81B43033D2A05BB6D457 /* ErrorBannerView.swift */; };
 		6A307B45767CCFC5C849E768 /* MeshContact.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1161B50A49EB13D5F04A483 /* MeshContact.swift */; };
 		6E5630576308F69837FC1115 /* MeshMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E2E7D792B46449387D7CCF5 /* MeshMessage.swift */; };
 		70B9FBE6B5E048DAC14725DD /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56461D95B5FDDE0284D51808 /* SidebarView.swift */; };
+		714B240A9E32D39EE8742549 /* ContactRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19B2FAB27F3E2D1527926B5 /* ContactRecord.swift */; };
 		84577897A1DE59F1786EFA77 /* MeshCoreBluetoothService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06738DDC341C7E858E03AD8B /* MeshCoreBluetoothService.swift */; };
 		85BC5BE5669E035D5503038A /* PairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABAF7CE52BB05ECC17BB6A9 /* PairingView.swift */; };
 		8A8C416FD816DC23E430844B /* MeshChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F252B6593A207542FC33F629 /* MeshChannel.swift */; };
 		8CE40DD49787024B9A2C01BE /* ChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439ED5DEA759FE234D8E52EB /* ChatViewModelTests.swift */; };
 		8D948FBADC80AFD85B20AD8C /* AppContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A2BDAE31B36B6DE45DF2C5 /* AppContainer.swift */; };
 		94702EFD3F235EADFA433180 /* MeshCoreMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960A39FBADB6994E9F8A2B58 /* MeshCoreMacApp.swift */; };
+		A480372F183AAE49A4B93CE8 /* ContactsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB30EB6BBF8251D7DE2973E /* ContactsViewModel.swift */; };
 		AA1691906E930CCFB8E96340 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 91D91B89374E00550EFAB2A3 /* GRDB */; };
 		AC4A633C040DAD6F76E8AC75 /* ConnectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB62BCAAF2AB404A352DEB9 /* ConnectionViewModelTests.swift */; };
 		B082CBD02C7FE6CAC1A07A42 /* MockBluetoothService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931A0F8508374D9F68718655 /* MockBluetoothService.swift */; };
 		B551983ED848D109C61593DB /* MessageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6729B12C60EE39C4AADEBAF8 /* MessageStore.swift */; };
 		B87EA3B4DFB49690D8E5BCEF /* SidebarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD14D5E1B5154CFE832006DE /* SidebarViewModel.swift */; };
 		C5FBF3C2437BD08E8CD28986 /* MessageBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95928FC45C3091FB70054481 /* MessageBubbleView.swift */; };
+		D06D5C25CBC4599D7E346411 /* ContactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC1AADE3C2ED3C1B53B690A /* ContactStore.swift */; };
 		D83FB62AFAB41BC9C0A565E3 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE90A4A21ED0FCBEF6033B11 /* SettingsView.swift */; };
 		DDD3C9980E838614D35AD6D9 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676154334E1F0D348D97CD08 /* ChatViewModel.swift */; };
 		E7ECB5EEE19A6878C6557A1E /* MeshCoreProtocolService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B84613F3B5ED907D545EEB /* MeshCoreProtocolService.swift */; };
 		ECB2D3B0ADB8B5B237A6FFE5 /* ConnectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C00FC41A96B64E044F5997B /* ConnectionViewModel.swift */; };
 		F9766A2FC5CAF84FFCB2C515 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309622427679B6678DB85655 /* MenuBarView.swift */; };
+		FF4568FA36F68B0766C5A43F /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B62EF0A7FA6F2CC7D5D10B /* MapView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,8 +64,10 @@
 		0758B0FE289EF74EC6DA0563 /* ConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionState.swift; sourceTree = "<group>"; };
 		16B84613F3B5ED907D545EEB /* MeshCoreProtocolService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshCoreProtocolService.swift; sourceTree = "<group>"; };
 		183805CD72006F83823BFC87 /* MeshCoreMacTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshCoreMacTests.swift; sourceTree = "<group>"; };
+		1AB30EB6BBF8251D7DE2973E /* ContactsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsViewModel.swift; sourceTree = "<group>"; };
 		309622427679B6678DB85655 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		36286B542A2D72477F42748F /* MessageStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStoreTests.swift; sourceTree = "<group>"; };
+		38D987A40EB870F66E60EC56 /* ContactsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsViewModelTests.swift; sourceTree = "<group>"; };
 		393807736FFBD890E13612F1 /* MainWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowView.swift; sourceTree = "<group>"; };
 		3DE3C73499500C29A157C3EE /* MeshCoreMac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MeshCoreMac.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		407C25969742DD6C873C36BF /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
@@ -73,6 +82,7 @@
 		6E3B2AAA9D808D2D8F4E36A3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		70F1C8E34ED7877138EE8DFD /* MessageStoreRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageStoreRecord.swift; sourceTree = "<group>"; };
 		7662F98A87064732146A9E28 /* MeshCoreProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshCoreProtocol.swift; sourceTree = "<group>"; };
+		76B62EF0A7FA6F2CC7D5D10B /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		7FB1294F545A99E8FF503052 /* BluetoothServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothServiceProtocol.swift; sourceTree = "<group>"; };
 		86A2BDAE31B36B6DE45DF2C5 /* AppContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppContainer.swift; sourceTree = "<group>"; };
 		8E2E7D792B46449387D7CCF5 /* MeshMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshMessage.swift; sourceTree = "<group>"; };
@@ -84,10 +94,14 @@
 		A271D0E9D5233362DEE0C700 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B647C2A265D4FE03D49FFAAC /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		C1161B50A49EB13D5F04A483 /* MeshContact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshContact.swift; sourceTree = "<group>"; };
+		CDC1AADE3C2ED3C1B53B690A /* ContactStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactStore.swift; sourceTree = "<group>"; };
 		CE90A4A21ED0FCBEF6033B11 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		D3857B6E683FD02DE91A5D77 /* ContactStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactStoreTests.swift; sourceTree = "<group>"; };
+		E19B2FAB27F3E2D1527926B5 /* ContactRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactRecord.swift; sourceTree = "<group>"; };
 		F252B6593A207542FC33F629 /* MeshChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshChannel.swift; sourceTree = "<group>"; };
 		FC6C81B43033D2A05BB6D457 /* ErrorBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBannerView.swift; sourceTree = "<group>"; };
 		FD14D5E1B5154CFE832006DE /* SidebarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewModel.swift; sourceTree = "<group>"; };
+		FE099058ECAA1C500D088343 /* ContactDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactDetailView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +120,7 @@
 			isa = PBXGroup;
 			children = (
 				665E3190BA543995976629C8 /* MainWindow */,
+				26EE5B7926AA9B51FBDD595B /* Map */,
 				C0471FDA3543887D49D4C5DF /* MenuBar */,
 				77F0115D6ACC05BE0A283719 /* Onboarding */,
 				4831A231D1155621ACD2DA24 /* Settings */,
@@ -127,6 +142,14 @@
 			path = MeshCoreMac;
 			sourceTree = "<group>";
 		};
+		26EE5B7926AA9B51FBDD595B /* Map */ = {
+			isa = PBXGroup;
+			children = (
+				76B62EF0A7FA6F2CC7D5D10B /* MapView.swift */,
+			);
+			path = Map;
+			sourceTree = "<group>";
+		};
 		2FBC050B92C74219A24A557B /* Shared */ = {
 			isa = PBXGroup;
 			children = (
@@ -140,6 +163,7 @@
 			children = (
 				439ED5DEA759FE234D8E52EB /* ChatViewModelTests.swift */,
 				9EB62BCAAF2AB404A352DEB9 /* ConnectionViewModelTests.swift */,
+				38D987A40EB870F66E60EC56 /* ContactsViewModelTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -148,6 +172,8 @@
 			isa = PBXGroup;
 			children = (
 				7FB1294F545A99E8FF503052 /* BluetoothServiceProtocol.swift */,
+				E19B2FAB27F3E2D1527926B5 /* ContactRecord.swift */,
+				CDC1AADE3C2ED3C1B53B690A /* ContactStore.swift */,
 				06738DDC341C7E858E03AD8B /* MeshCoreBluetoothService.swift */,
 				7662F98A87064732146A9E28 /* MeshCoreProtocol.swift */,
 				16B84613F3B5ED907D545EEB /* MeshCoreProtocolService.swift */,
@@ -189,6 +215,7 @@
 			isa = PBXGroup;
 			children = (
 				407C25969742DD6C873C36BF /* ChatView.swift */,
+				FE099058ECAA1C500D088343 /* ContactDetailView.swift */,
 				393807736FFBD890E13612F1 /* MainWindowView.swift */,
 				95928FC45C3091FB70054481 /* MessageBubbleView.swift */,
 				56461D95B5FDDE0284D51808 /* SidebarView.swift */,
@@ -207,6 +234,7 @@
 		6C43BC4EEDAC3A083A914F91 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				D3857B6E683FD02DE91A5D77 /* ContactStoreTests.swift */,
 				40EF55C96200FE31C411F79A /* MeshCoreProtocolServiceTests.swift */,
 				36286B542A2D72477F42748F /* MessageStoreTests.swift */,
 				931A0F8508374D9F68718655 /* MockBluetoothService.swift */,
@@ -238,6 +266,7 @@
 			children = (
 				676154334E1F0D348D97CD08 /* ChatViewModel.swift */,
 				6C00FC41A96B64E044F5997B /* ConnectionViewModel.swift */,
+				1AB30EB6BBF8251D7DE2973E /* ContactsViewModel.swift */,
 				FD14D5E1B5154CFE832006DE /* SidebarViewModel.swift */,
 			);
 			path = ViewModels;
@@ -352,6 +381,8 @@
 			files = (
 				8CE40DD49787024B9A2C01BE /* ChatViewModelTests.swift in Sources */,
 				AC4A633C040DAD6F76E8AC75 /* ConnectionViewModelTests.swift in Sources */,
+				0C098BCE92A76BF310CB1AF3 /* ContactStoreTests.swift in Sources */,
+				605F5416EE031A40776F65DF /* ContactsViewModelTests.swift in Sources */,
 				16CCE33A639DBCBAA7940DAA /* MeshCoreMacTests.swift in Sources */,
 				61A84A02A228C2AACF690437 /* MeshCoreProtocolServiceTests.swift in Sources */,
 				4A9362842023A58F1E2120A0 /* MeshMessageTests.swift in Sources */,
@@ -371,8 +402,13 @@
 				DDD3C9980E838614D35AD6D9 /* ChatViewModel.swift in Sources */,
 				448C88E05CE4B31F44934165 /* ConnectionState.swift in Sources */,
 				ECB2D3B0ADB8B5B237A6FFE5 /* ConnectionViewModel.swift in Sources */,
+				3CC3F1C10E6762928FBEDDF1 /* ContactDetailView.swift in Sources */,
+				714B240A9E32D39EE8742549 /* ContactRecord.swift in Sources */,
+				D06D5C25CBC4599D7E346411 /* ContactStore.swift in Sources */,
+				A480372F183AAE49A4B93CE8 /* ContactsViewModel.swift in Sources */,
 				6A1D9AF51D03ECFC4F90028C /* ErrorBannerView.swift in Sources */,
 				25BFD0400337844A44EABC45 /* MainWindowView.swift in Sources */,
+				FF4568FA36F68B0766C5A43F /* MapView.swift in Sources */,
 				F9766A2FC5CAF84FFCB2C515 /* MenuBarView.swift in Sources */,
 				8A8C416FD816DC23E430844B /* MeshChannel.swift in Sources */,
 				6A307B45767CCFC5C849E768 /* MeshContact.swift in Sources */,

--- a/MeshCoreMac/App/AppContainer.swift
+++ b/MeshCoreMac/App/AppContainer.swift
@@ -5,15 +5,19 @@ import Foundation
 final class AppContainer {
     let bluetoothService: MeshCoreBluetoothService
     let messageStore: MessageStore
+    let contactStore: ContactStore
     let connectionViewModel: ConnectionViewModel
     let sidebarViewModel: SidebarViewModel
+    let contactsViewModel: ContactsViewModel
     let notificationService: NotificationService
 
     init() throws {
         bluetoothService = MeshCoreBluetoothService()
         messageStore = try MessageStore()
+        contactStore = try ContactStore()
         connectionViewModel = ConnectionViewModel(bluetoothService: bluetoothService)
         sidebarViewModel = SidebarViewModel()
+        contactsViewModel = ContactsViewModel(contactStore: contactStore, bluetoothService: bluetoothService)
         notificationService = NotificationService()
     }
 

--- a/MeshCoreMac/App/MeshCoreMacApp.swift
+++ b/MeshCoreMac/App/MeshCoreMacApp.swift
@@ -20,6 +20,7 @@ struct MeshCoreMacApp: App {
     var body: some Scene {
         WindowGroup {
             MainWindowView(container: container)
+                .task { await container.contactsViewModel.start() }
                 .onDisappear {
                     appDelegate.switchToAccessoryMode()
                 }

--- a/MeshCoreMac/Models/MeshContact.swift
+++ b/MeshCoreMac/Models/MeshContact.swift
@@ -1,8 +1,10 @@
 import Foundation
 
 struct MeshContact: Identifiable, Hashable, Sendable {
-    let id: String     // Hex-Node-Adresse aus MeshCore (z.B. "a1b2c3d4")
+    let id: String     // Hex-Node-Adresse (z.B. "a1b2c3d4")
     var name: String
     var lastSeen: Date?
     var isOnline: Bool
+    var lat: Double?
+    var lon: Double?
 }

--- a/MeshCoreMac/Models/MeshContact.swift
+++ b/MeshCoreMac/Models/MeshContact.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct MeshContact: Identifiable, Hashable, Sendable {
-    let id: String     // Hex-Node-Adresse (z.B. "a1b2c3d4")
+    let id: String     // Hex-Node-Adresse aus MeshCore (z.B. "a1b2c3d4")
     var name: String
     var lastSeen: Date?
     var isOnline: Bool

--- a/MeshCoreMac/Services/BluetoothServiceProtocol.swift
+++ b/MeshCoreMac/Services/BluetoothServiceProtocol.swift
@@ -11,7 +11,10 @@ import Foundation
 protocol BluetoothServiceProtocol: AnyObject {
     var connectionState: ConnectionState { get }
     var discoveredDevices: [CBPeripheral] { get }
+    /// Rohe BLE-Frames (Node → App). ChatViewModel konsumiert diesen Stream.
     var incomingFrames: AsyncStream<Data> { get }
+    /// Dekodierte Node-Ereignisse: selfInfo, nodeAdvert, contact, contactsStart/End.
+    var nodeEventStream: AsyncStream<DecodedFrame> { get }
 
     func startScanning()
     func stopScanning()

--- a/MeshCoreMac/Services/ContactRecord.swift
+++ b/MeshCoreMac/Services/ContactRecord.swift
@@ -1,3 +1,4 @@
+// MeshCoreMac/Services/ContactRecord.swift
 import GRDB
 import Foundation
 

--- a/MeshCoreMac/Services/ContactRecord.swift
+++ b/MeshCoreMac/Services/ContactRecord.swift
@@ -1,0 +1,33 @@
+import GRDB
+import Foundation
+
+struct ContactRecord: Codable, FetchableRecord, PersistableRecord {
+    static let databaseTableName = "contacts"
+
+    var id: String
+    var name: String
+    var lastSeen: Double?   // Date.timeIntervalSince1970
+    var isOnline: Bool
+    var lat: Double?
+    var lon: Double?
+
+    init(from contact: MeshContact) {
+        id = contact.id
+        name = contact.name
+        lastSeen = contact.lastSeen?.timeIntervalSince1970
+        isOnline = contact.isOnline
+        lat = contact.lat
+        lon = contact.lon
+    }
+
+    func toMeshContact() -> MeshContact {
+        MeshContact(
+            id: id,
+            name: name,
+            lastSeen: lastSeen.map { Date(timeIntervalSince1970: $0) },
+            isOnline: isOnline,
+            lat: lat,
+            lon: lon
+        )
+    }
+}

--- a/MeshCoreMac/Services/ContactStore.swift
+++ b/MeshCoreMac/Services/ContactStore.swift
@@ -1,0 +1,68 @@
+import GRDB
+import Foundation
+
+final class ContactStore: Sendable {
+    private let dbQueue: DatabaseQueue
+
+    init(inMemory: Bool = false) throws {
+        if inMemory {
+            dbQueue = try DatabaseQueue()
+        } else {
+            let appSupport = try FileManager.default.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+            let dbURL = appSupport
+                .appendingPathComponent("MeshCoreMac", isDirectory: true)
+                .appendingPathComponent("contacts.sqlite")
+            try FileManager.default.createDirectory(
+                at: dbURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            dbQueue = try DatabaseQueue(path: dbURL.path)
+        }
+        try runMigrations()
+    }
+
+    private func runMigrations() throws {
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration("v1_create_contacts") { db in
+            try db.create(table: ContactRecord.databaseTableName, ifNotExists: true) { t in
+                t.column("id", .text).primaryKey()
+                t.column("name", .text).notNull()
+                t.column("lastSeen", .double)
+                t.column("isOnline", .boolean).notNull()
+                t.column("lat", .double)
+                t.column("lon", .double)
+            }
+        }
+        try migrator.migrate(dbQueue)
+    }
+
+    func save(_ contact: MeshContact) async throws {
+        let record = ContactRecord(from: contact)
+        try await dbQueue.write { db in
+            try record.save(db)
+        }
+    }
+
+    func fetchAll() async throws -> [MeshContact] {
+        try await dbQueue.read { db in
+            try ContactRecord.fetchAll(db).map { $0.toMeshContact() }
+        }
+    }
+
+    func fetch(id: String) async throws -> MeshContact? {
+        try await dbQueue.read { db in
+            try ContactRecord.fetchOne(db, key: id)?.toMeshContact()
+        }
+    }
+
+    func delete(id: String) async throws {
+        try await dbQueue.write { db in
+            _ = try ContactRecord.deleteOne(db, key: id)
+        }
+    }
+}

--- a/MeshCoreMac/Services/ContactStore.swift
+++ b/MeshCoreMac/Services/ContactStore.swift
@@ -1,3 +1,4 @@
+// MeshCoreMac/Services/ContactStore.swift
 import GRDB
 import Foundation
 
@@ -26,6 +27,7 @@ final class ContactStore: Sendable {
         try runMigrations()
     }
 
+    // MARK: - Migrations
     private func runMigrations() throws {
         var migrator = DatabaseMigrator()
         migrator.registerMigration("v1_create_contacts") { db in
@@ -41,6 +43,7 @@ final class ContactStore: Sendable {
         try migrator.migrate(dbQueue)
     }
 
+    // MARK: - Write
     func save(_ contact: MeshContact) async throws {
         let record = ContactRecord(from: contact)
         try await dbQueue.write { db in
@@ -48,6 +51,7 @@ final class ContactStore: Sendable {
         }
     }
 
+    // MARK: - Read
     func fetchAll() async throws -> [MeshContact] {
         try await dbQueue.read { db in
             try ContactRecord.fetchAll(db).map { $0.toMeshContact() }

--- a/MeshCoreMac/Services/MeshCoreBluetoothService.swift
+++ b/MeshCoreMac/Services/MeshCoreBluetoothService.swift
@@ -28,6 +28,8 @@ final class MeshCoreBluetoothService: NSObject, BluetoothServiceProtocol {
     // MARK: - Async Frame Stream
     let incomingFrames: AsyncStream<Data>
     private let frameContinuation: AsyncStream<Data>.Continuation
+    let nodeEventStream: AsyncStream<DecodedFrame>
+    private let nodeEventContinuation: AsyncStream<DecodedFrame>.Continuation
 
     // MARK: - CoreBluetooth
     private var centralManager: CBCentralManager!
@@ -48,12 +50,16 @@ final class MeshCoreBluetoothService: NSObject, BluetoothServiceProtocol {
         let (stream, continuation) = AsyncStream<Data>.makeStream()
         self.incomingFrames = stream
         self.frameContinuation = continuation
+        let (nodeStream, nodeCont) = AsyncStream<DecodedFrame>.makeStream()
+        self.nodeEventStream = nodeStream
+        self.nodeEventContinuation = nodeCont
         super.init()
         self.centralManager = CBCentralManager(delegate: self, queue: .main)
     }
 
     deinit {
         frameContinuation.finish()
+        nodeEventContinuation.finish()
     }
 
     // MARK: - Public API
@@ -250,11 +256,22 @@ extension MeshCoreBluetoothService: @preconcurrency CBPeripheralDelegate {
     ) {
         guard error == nil, let value = characteristic.value else { return }
         frameContinuation.yield(value)
+
+        // Route decoded node events to nodeEventStream (ChatViewModel ignores these via break)
+        if let decoded = try? MeshCoreProtocolService.decodeFrame(value) {
+            switch decoded {
+            case .selfInfo, .nodeAdvert, .contact, .contactsStart, .contactsEnd:
+                nodeEventContinuation.yield(decoded)
+            case .newChannelMessage, .newDirectMessage, .messageAck:
+                break
+            }
+        }
     }
 
     private func sendInitSequence() {
         try? send(MeshCoreProtocolService.encodeAppStart())
         try? send(MeshCoreProtocolService.encodeDeviceQuery())
+        try? send(MeshCoreProtocolService.encodeGetContacts())
     }
 }
 

--- a/MeshCoreMac/Services/MeshCoreBluetoothService.swift
+++ b/MeshCoreMac/Services/MeshCoreBluetoothService.swift
@@ -39,7 +39,7 @@ final class MeshCoreBluetoothService: NSObject, BluetoothServiceProtocol {
 
     // MARK: - Reconnect
     private var lastKnownPeripheralId: UUID?
-    private var reconnectTask: Task<Void, Never>?
+    nonisolated(unsafe) private var reconnectTask: Task<Void, Never>?
 
     // MARK: - Konstanten
     private static let lastPeripheralIdKey = "lastPeripheralId"
@@ -58,6 +58,7 @@ final class MeshCoreBluetoothService: NSObject, BluetoothServiceProtocol {
     }
 
     deinit {
+        reconnectTask?.cancel()
         frameContinuation.finish()
         nodeEventContinuation.finish()
     }

--- a/MeshCoreMac/Services/MeshCoreProtocol.swift
+++ b/MeshCoreMac/Services/MeshCoreProtocol.swift
@@ -96,11 +96,19 @@ enum MeshCoreProtocol {
 
 /// Strukturiertes Ergebnis nach erfolgreichem Frame-Decode.
 enum DecodedFrame: Sendable, Equatable {
-    case deviceInfo(nodeId: String, firmwareVersion: String)
+    /// Eigene Node-Info mit optionaler GPS-Position (SELF_INFO 0x05, DEVICE_INFO 0x0D).
+    case selfInfo(nodeId: String, lat: Double?, lon: Double?, firmware: String)
     case newChannelMessage(MeshMessage)
     case newDirectMessage(MeshMessage)
     case messageAck(messageId: String)
-    case nodeStatus(contactId: String, isOnline: Bool)
+    /// Werbung eines anderen Nodes mit optionaler Position (ADVERT 0x80, PATH_UPDATED 0x81).
+    case nodeAdvert(contactId: String, name: String?, lat: Double?, lon: Double?)
+    /// Ein Kontakt aus der GET_CONTACTS-Antwort-Sequenz (CONTACT 0x03).
+    case contact(MeshContact)
+    /// Startsignal der GET_CONTACTS-Antwort (CONTACTS_START 0x02).
+    case contactsStart
+    /// Endsignal der GET_CONTACTS-Antwort (END_OF_CONTACTS 0x04).
+    case contactsEnd
 }
 
 // MARK: - Fehler

--- a/MeshCoreMac/Services/MeshCoreProtocolService.swift
+++ b/MeshCoreMac/Services/MeshCoreProtocolService.swift
@@ -1,15 +1,12 @@
 // MeshCoreMac/Services/MeshCoreProtocolService.swift
 //
 // Encode/Decode für das MeshCore Companion-BLE-Protokoll.
-//
 // Quelle: https://docs.meshcore.io/companion_protocol/
-//         https://github.com/meshcore-dev/MeshCore/wiki/Companion-Radio-Protocol
 //
-// Das echte V3-Frame-Format für Channel/Contact-Messages ist umfangreicher
-// (Timestamp, pubkey-Prefix, Pfad, SNR×0.25). Für Phase 1 implementieren wir
-// einen reduzierten Decoder, der die im Plan/Tests definierten Felder liefert.
-// VERIFY: Vor BLE-Service-Integration (Task 5) gegen reale Firmware-Frames
-//         abgleichen und ggf. erweitern.
+// Frame-Formate:
+//   SELF_INFO/ADVERT payload: [pubkey:32][ts:4][lat_f32_le:4][lon_f32_le:4][alt_f32_le:4][name:variable]
+//   CONTACT payload:          [pubkey:32][last_heard:4][flags:1][name:variable]
+// VERIFY: Bei neuer Firmware-Version gegen reale Frames abgleichen.
 
 import Foundation
 
@@ -17,29 +14,18 @@ enum MeshCoreProtocolService {
 
     // MARK: - Encoder
 
-    /// CMD_APP_START: muss als erstes nach Verbindungsaufbau gesendet werden.
-    /// Format laut Spec: [0x01][app_ver][reserved×6][app_name UTF-8].
-    /// Phase 1: Minimal-Frame mit nur dem Command-Byte (Firmware ignoriert
-    /// fehlende Reserved-Bytes laut älterer Spec). VERIFY mit echter Firmware.
     static func encodeAppStart() -> Data {
         Data([MeshCoreProtocol.Command.appStart.rawValue])
     }
 
-    /// CMD_DEVICE_QUERY: fragt Device-Info an.
-    /// Format laut Spec: [0x16][app_target_ver]. Phase 1: nur Command-Byte.
-    /// VERIFY mit echter Firmware.
     static func encodeDeviceQuery() -> Data {
         Data([MeshCoreProtocol.Command.deviceQuery.rawValue])
     }
 
-    /// Encodiert eine Textnachricht.
-    ///
-    /// - Channel-Message: `[0x02][channelIndex][text]` (Plan-Spec für Tests).
-    ///   Echtes Spec-Frame `CMD_SEND_CHANNEL_TXT_MSG (0x03)` enthält zusätzlich
-    ///   timestamp und 0x00-Padding-Byte. VERIFY für Task 5.
-    /// - DM: `[0x02][channelIndex=0][text]`. Recipient-Adressierung in Phase 1
-    ///   nicht implementiert. VERIFY für DM-Support (echtes Spec verwendet
-    ///   pubkey_prefix mit 6 Bytes).
+    static func encodeGetContacts() -> Data {
+        Data([MeshCoreProtocol.Command.getContacts.rawValue])
+    }
+
     static func encodeSendTextMessage(
         text: String,
         channelIndex: UInt8,
@@ -51,7 +37,6 @@ enum MeshCoreProtocolService {
         guard textData.count <= MeshCoreProtocol.maxMessageLength else {
             throw ProtocolError.messageTooLong(textData.count)
         }
-        // Frame: [CMD][channelIndex][text_utf8...]
         var frame = Data([MeshCoreProtocol.Command.sendTxtMsg.rawValue, channelIndex])
         frame.append(textData)
         return frame
@@ -59,40 +44,39 @@ enum MeshCoreProtocolService {
 
     // MARK: - Decoder
 
-    /// Dispatcht einen eingehenden Frame anhand des Command-Bytes.
     static func decodeFrame(_ data: Data) throws -> DecodedFrame {
         guard !data.isEmpty else { throw ProtocolError.emptyFrame }
 
         let commandByte = data[data.startIndex]
         let payload = data.dropFirst()
 
-        // Sync-Responses
         if let response = MeshCoreProtocol.Response(rawValue: commandByte) {
             switch response {
-            case .deviceInfo, .selfInfo:
-                return try decodeDeviceInfo(payload)
+            case .selfInfo, .deviceInfo:
+                return try decodeNodeInfo(payload)
             case .channelMsgRecv:
                 return try decodeChannelMessage(payload)
             case .contactMsgRecv:
                 return try decodeContactMessage(payload)
             case .sent:
                 return try decodeMsgAck(payload)
-            case .ok, .err, .contactsStart, .contact, .endOfContacts,
-                 .currTime, .noMoreMessages, .battAndStorage:
+            case .contactsStart:
+                return .contactsStart
+            case .contact:
+                return try decodeContact(payload)
+            case .endOfContacts:
+                return .contactsEnd
+            case .ok, .err, .currTime, .noMoreMessages, .battAndStorage:
                 throw ProtocolError.unknownCommand(commandByte)
             }
         }
 
-        // VERIFY Task 5: ResponseV3 (0x10, 0x11) dispatch deferred — V3 frames
-        // currently rejected with unknownCommand until real firmware frames are tested
-
-        // Push-Notifications
         if let push = MeshCoreProtocol.Push(rawValue: commandByte) {
             switch push {
             case .sendConfirmed:
                 return try decodeMsgAck(payload)
             case .advert, .pathUpdated:
-                return try decodeNodeStatusFromAdvert(payload, isOnline: true)
+                return try decodeAdvertOrSelfInfo(payload)
             case .msgWaiting, .rawData, .loginSuccess, .loginFail, .statusResponse:
                 throw ProtocolError.unknownCommand(commandByte)
             }
@@ -103,26 +87,84 @@ enum MeshCoreProtocolService {
 
     // MARK: - Private Decode Helpers
 
-    /// Reduzierter DEVICE_INFO/SELF_INFO Decode für Phase 1.
-    /// Echtes Spec-Format ist deutlich größer (32-Byte pubkey, lat/lon, etc.).
-    /// VERIFY: Vor Task 5 gegen reale Firmware-Frames abgleichen.
-    private static func decodeDeviceInfo(_ payload: Data) throws -> DecodedFrame {
-        guard payload.count >= 4 else {
-            throw ProtocolError.invalidPayload("DEVICE_INFO payload zu kurz")
+    /// Dekodiert SELF_INFO (0x05) und DEVICE_INFO (0x0D) Responses.
+    /// Format: [pubkey:32][ts:4][lat_f32_le:4][lon_f32_le:4][alt_f32_le:4][name:variable]
+    private static func decodeNodeInfo(_ payload: Data) throws -> DecodedFrame {
+        let bytes = Array(payload)
+        guard bytes.count >= 4 else {
+            throw ProtocolError.invalidPayload("NODE_INFO payload zu kurz")
         }
-        let nodeId = payload.prefix(4).map { String(format: "%02x", $0) }.joined()
-        let firmware = String(data: payload.dropFirst(4), encoding: .utf8) ?? "unbekannt"
-        return .deviceInfo(nodeId: nodeId, firmwareVersion: firmware)
+        let nodeId = bytes.prefix(4).map { String(format: "%02x", $0) }.joined()
+        if bytes.count >= 48 {
+            let lat = readFloat32LE(bytes, offset: 36).map(Double.init)
+            let lon = readFloat32LE(bytes, offset: 40).map(Double.init)
+            let hasPosition = lat != 0.0 || lon != 0.0
+            let rawName = Data(bytes.dropFirst(48))
+            let nameEnd = rawName.firstIndex(of: 0) ?? rawName.endIndex
+            let firmware = String(data: rawName[rawName.startIndex..<nameEnd], encoding: .utf8) ?? "unbekannt"
+            return .selfInfo(
+                nodeId: nodeId,
+                lat: hasPosition ? lat : nil,
+                lon: hasPosition ? lon : nil,
+                firmware: firmware
+            )
+        }
+        // Fallback für kurze Frames ohne Positions-Payload
+        let firmware = String(data: Data(bytes.dropFirst(4)), encoding: .utf8) ?? "unbekannt"
+        return .selfInfo(nodeId: nodeId, lat: nil, lon: nil, firmware: firmware)
     }
 
-    /// Channel-Message Decode (Plan-Format für TDD-Tests).
-    ///
-    /// Frame nach Command-Byte: `[channelIndex][hops][snr_raw_signed][text_utf8...]`
-    ///
-    /// VERIFY: Echtes V3-Format (`RESP_CODE_CHANNEL_MSG_RECV_V3 = 0x11`)
-    ///         enthält zusätzlich sender_timestamp (uint32 LE) und längere
-    ///         Header. SNR wird als signed_byte × 0.25 dB skaliert. Phase 1
-    ///         arbeitet zunächst mit dem reduzierten Plan-Frame.
+    /// Dekodiert ADVERT (0x80) und PATH_UPDATED (0x81) Push-Notifications.
+    /// Format: [pubkey:32][ts:4][lat_f32_le:4][lon_f32_le:4][alt_f32_le:4][name:variable]
+    private static func decodeAdvertOrSelfInfo(_ payload: Data) throws -> DecodedFrame {
+        let bytes = Array(payload)
+        guard bytes.count >= 4 else {
+            throw ProtocolError.invalidPayload("ADVERT payload zu kurz")
+        }
+        let contactId = bytes.prefix(4).map { String(format: "%02x", $0) }.joined()
+        if bytes.count >= 48 {
+            let lat = readFloat32LE(bytes, offset: 36).map(Double.init)
+            let lon = readFloat32LE(bytes, offset: 40).map(Double.init)
+            let hasPosition = lat != 0.0 || lon != 0.0
+            let rawName = Data(bytes.dropFirst(48))
+            let nameEnd = rawName.firstIndex(of: 0) ?? rawName.endIndex
+            let name = String(data: rawName[rawName.startIndex..<nameEnd], encoding: .utf8)
+            return .nodeAdvert(
+                contactId: contactId,
+                name: name?.isEmpty == false ? name : nil,
+                lat: hasPosition ? lat : nil,
+                lon: hasPosition ? lon : nil
+            )
+        }
+        return .nodeAdvert(contactId: contactId, name: nil, lat: nil, lon: nil)
+    }
+
+    /// Dekodiert einen einzelnen CONTACT (0x03) aus der GET_CONTACTS-Sequenz.
+    /// Format: [pubkey:32][last_heard:4][flags:1][name:variable]
+    private static func decodeContact(_ payload: Data) throws -> DecodedFrame {
+        let bytes = Array(payload)
+        guard bytes.count >= 37 else {
+            throw ProtocolError.invalidPayload("CONTACT payload zu kurz")
+        }
+        let contactId = bytes.prefix(4).map { String(format: "%02x", $0) }.joined()
+        let lastHeardSecs = UInt32(bytes[32]) | UInt32(bytes[33]) << 8 |
+                            UInt32(bytes[34]) << 16 | UInt32(bytes[35]) << 24
+        let lastSeen: Date? = lastHeardSecs > 0
+            ? Date(timeIntervalSince1970: TimeInterval(lastHeardSecs)) : nil
+        let flags = bytes[36]
+        let isOnline = (flags & 0x01) != 0
+        let nameData = Data(bytes.dropFirst(37))
+        let name = String(data: nameData, encoding: .utf8)?.trimmingCharacters(in: .controlCharacters)
+        return .contact(MeshContact(
+            id: contactId,
+            name: name?.isEmpty == false ? name! : contactId,
+            lastSeen: lastSeen,
+            isOnline: isOnline,
+            lat: nil,
+            lon: nil
+        ))
+    }
+
     private static func decodeChannelMessage(_ payload: Data) throws -> DecodedFrame {
         guard payload.count >= 3 else {
             throw ProtocolError.invalidPayload("CHANNEL_MSG payload zu kurz")
@@ -131,8 +173,6 @@ enum MeshCoreProtocolService {
         let channelIndex = Int(bytes[0])
         let hops = Int(bytes[1])
         let snrRaw = Int8(bitPattern: bytes[2])
-        // VERIFY: Skalierung für V3 ist 0.25; im Plan-Frame ungescaled.
-        let snr = Float(snrRaw)
         let textData = Data(bytes.dropFirst(3))
         guard let text = String(data: textData, encoding: .utf8) else {
             throw ProtocolError.invalidPayload("Nachrichtentext kein gültiges UTF-8")
@@ -140,20 +180,16 @@ enum MeshCoreProtocolService {
         let msg = MeshMessage(
             id: UUID(),
             kind: .channel(index: channelIndex),
-            senderName: "Unbekannt",  // VERIFY: Echtes Frame liefert pubkey-Prefix
+            senderName: "Unbekannt",
             text: text,
             timestamp: Date(),
-            routing: MeshMessage.Routing(hops: hops, snr: snr, routeDisplay: nil),
+            routing: MeshMessage.Routing(hops: hops, snr: Float(snrRaw), routeDisplay: nil),
             deliveryStatus: .delivered,
             isIncoming: true
         )
         return .newChannelMessage(msg)
     }
 
-    /// Contact-Message (DM) Decode.
-    ///
-    /// Frame nach Command-Byte: `[contactId×4][hops][snr_raw_signed][text_utf8...]`
-    /// VERIFY: Echtes V3-Format weicht ab (pubkey-Prefix 6 Bytes).
     private static func decodeContactMessage(_ payload: Data) throws -> DecodedFrame {
         guard payload.count >= 6 else {
             throw ProtocolError.invalidPayload("CONTACT_MSG payload zu kurz")
@@ -179,24 +215,20 @@ enum MeshCoreProtocolService {
         return .newDirectMessage(msg)
     }
 
-    /// Send-Confirmed / ACK-Decode.
-    /// VERIFY: Echtes ACK-Format spezifizieren (vermutlich message-hash).
     private static func decodeMsgAck(_ payload: Data) throws -> DecodedFrame {
         let msgId = payload.map { String(format: "%02x", $0) }.joined()
         return .messageAck(messageId: msgId)
     }
 
-    /// PUSH_CODE_ADVERT: pubkey eines neu gesehenen Nodes.
-    /// Format: [pubkey×32]. Wir nehmen die ersten 4 Bytes als contactId.
-    /// VERIFY: für Phase 1 ausreichend; ContactStore wird in Task 4/5 erweitert.
-    private static func decodeNodeStatusFromAdvert(
-        _ payload: Data,
-        isOnline: Bool
-    ) throws -> DecodedFrame {
-        guard payload.count >= 4 else {
-            throw ProtocolError.invalidPayload("ADVERT payload zu kurz")
-        }
-        let contactId = payload.prefix(4).map { String(format: "%02x", $0) }.joined()
-        return .nodeStatus(contactId: contactId, isOnline: isOnline)
+    // MARK: - Byte Helpers
+
+    /// Liest Float32 little-endian aus einem Byte-Array ab `offset`.
+    private static func readFloat32LE(_ bytes: [UInt8], offset: Int) -> Float? {
+        guard offset + 3 < bytes.count else { return nil }
+        let bits = UInt32(bytes[offset])
+            | UInt32(bytes[offset + 1]) << 8
+            | UInt32(bytes[offset + 2]) << 16
+            | UInt32(bytes[offset + 3]) << 24
+        return Float(bitPattern: bits)
     }
 }

--- a/MeshCoreMac/Services/MeshCoreProtocolService.swift
+++ b/MeshCoreMac/Services/MeshCoreProtocolService.swift
@@ -15,10 +15,12 @@ enum MeshCoreProtocolService {
     // MARK: - Encoder
 
     static func encodeAppStart() -> Data {
+        // VERIFY: Minimal-Frame. Echtes Spec-Format: [0x01][app_ver][reserved×6][app_name UTF-8].
         Data([MeshCoreProtocol.Command.appStart.rawValue])
     }
 
     static func encodeDeviceQuery() -> Data {
+        // VERIFY: Minimal-Frame. Echtes Spec-Format: [0x16][app_target_ver].
         Data([MeshCoreProtocol.Command.deviceQuery.rawValue])
     }
 
@@ -37,6 +39,8 @@ enum MeshCoreProtocolService {
         guard textData.count <= MeshCoreProtocol.maxMessageLength else {
             throw ProtocolError.messageTooLong(textData.count)
         }
+        // VERIFY: Echtes CMD_SEND_CHANNEL_TXT_MSG (0x03) enthält zusätzlich Timestamp und 0x00-Padding.
+        // DM-Format benötigt 6-Byte pubkey-Prefix für Recipient-Adressierung (Phase 2+).
         var frame = Data([MeshCoreProtocol.Command.sendTxtMsg.rawValue, channelIndex])
         frame.append(textData)
         return frame
@@ -76,7 +80,7 @@ enum MeshCoreProtocolService {
             case .sendConfirmed:
                 return try decodeMsgAck(payload)
             case .advert, .pathUpdated:
-                return try decodeAdvertOrSelfInfo(payload)
+                return try decodeNodeAdvertPush(payload)
             case .msgWaiting, .rawData, .loginSuccess, .loginFail, .statusResponse:
                 throw ProtocolError.unknownCommand(commandByte)
             }
@@ -116,7 +120,7 @@ enum MeshCoreProtocolService {
 
     /// Dekodiert ADVERT (0x80) und PATH_UPDATED (0x81) Push-Notifications.
     /// Format: [pubkey:32][ts:4][lat_f32_le:4][lon_f32_le:4][alt_f32_le:4][name:variable]
-    private static func decodeAdvertOrSelfInfo(_ payload: Data) throws -> DecodedFrame {
+    private static func decodeNodeAdvertPush(_ payload: Data) throws -> DecodedFrame {
         let bytes = Array(payload)
         guard bytes.count >= 4 else {
             throw ProtocolError.invalidPayload("ADVERT payload zu kurz")

--- a/MeshCoreMac/Services/MeshCoreProtocolService.swift
+++ b/MeshCoreMac/Services/MeshCoreProtocolService.swift
@@ -153,8 +153,9 @@ enum MeshCoreProtocolService {
             ? Date(timeIntervalSince1970: TimeInterval(lastHeardSecs)) : nil
         let flags = bytes[36]
         let isOnline = (flags & 0x01) != 0
-        let nameData = Data(bytes.dropFirst(37))
-        let name = String(data: nameData, encoding: .utf8)?.trimmingCharacters(in: .controlCharacters)
+        let rawName = Data(bytes.dropFirst(37))
+        let nameEnd = rawName.firstIndex(of: 0) ?? rawName.endIndex
+        let name = String(data: rawName[rawName.startIndex..<nameEnd], encoding: .utf8)
         return .contact(MeshContact(
             id: contactId,
             name: name?.isEmpty == false ? name! : contactId,

--- a/MeshCoreMac/ViewModels/ChatViewModel.swift
+++ b/MeshCoreMac/ViewModels/ChatViewModel.swift
@@ -120,10 +120,7 @@ final class ChatViewModel {
                     )
                 }
 
-            case .deviceInfo:
-                break
-
-            case .nodeStatus:
+            case .selfInfo, .nodeAdvert, .contact, .contactsStart, .contactsEnd:
                 break
             }
         } catch {

--- a/MeshCoreMac/ViewModels/ContactsViewModel.swift
+++ b/MeshCoreMac/ViewModels/ContactsViewModel.swift
@@ -13,6 +13,8 @@ final class ContactsViewModel {
     private let bluetoothService: any BluetoothServiceProtocol
 
     nonisolated(unsafe) private var listenerTask: Task<Void, Never>?
+    private var pendingContacts: [MeshContact] = []
+    private var collectingContacts = false
 
     init(contactStore: ContactStore, bluetoothService: any BluetoothServiceProtocol) {
         self.contactStore = contactStore
@@ -58,9 +60,28 @@ final class ContactsViewModel {
             upsert(c)
         case .contact(let c):
             try? await contactStore.save(c)
-            upsert(c)
-        case .contactsStart, .contactsEnd:
-            break
+            if collectingContacts {
+                // Buffer during GET_CONTACTS sequence; list replaced on contactsEnd
+                if let idx = pendingContacts.firstIndex(where: { $0.id == c.id }) {
+                    pendingContacts[idx] = c
+                } else {
+                    pendingContacts.append(c)
+                }
+            } else {
+                upsert(c)
+            }
+        case .contactsStart:
+            pendingContacts = []
+            collectingContacts = true
+        case .contactsEnd:
+            if collectingContacts {
+                // Merge GET_CONTACTS list: replace known list, keep ADVERT-only nodes
+                let listedIds = Set(pendingContacts.map { $0.id })
+                let advertOnly = contacts.filter { !listedIds.contains($0.id) }
+                contacts = pendingContacts + advertOnly
+                collectingContacts = false
+                pendingContacts = []
+            }
         case .newChannelMessage, .newDirectMessage, .messageAck:
             break
         }
@@ -74,5 +95,5 @@ final class ContactsViewModel {
         }
     }
 
-    deinit { listenerTask?.cancel() }
+    deinit { listenerTask?.cancel() }  // Task.cancel() ist nonisolated — erlaubt
 }

--- a/MeshCoreMac/ViewModels/ContactsViewModel.swift
+++ b/MeshCoreMac/ViewModels/ContactsViewModel.swift
@@ -1,0 +1,78 @@
+// MeshCoreMac/ViewModels/ContactsViewModel.swift
+import CoreLocation
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ContactsViewModel {
+    private(set) var contacts: [MeshContact] = []
+    private(set) var ownPosition: CLLocationCoordinate2D? = nil
+
+    private let contactStore: ContactStore
+    private let bluetoothService: any BluetoothServiceProtocol
+
+    nonisolated(unsafe) private var listenerTask: Task<Void, Never>?
+
+    init(contactStore: ContactStore, bluetoothService: any BluetoothServiceProtocol) {
+        self.contactStore = contactStore
+        self.bluetoothService = bluetoothService
+    }
+
+    func start() async {
+        contacts = (try? await contactStore.fetchAll()) ?? []
+        startListening()
+    }
+
+    func updateContact(_ contact: MeshContact) async {
+        try? await contactStore.save(contact)
+        upsert(contact)
+    }
+
+    private func startListening() {
+        listenerTask?.cancel()
+        listenerTask = Task {
+            for await event in self.bluetoothService.nodeEventStream {
+                guard !Task.isCancelled else { break }
+                await self.handleNodeEvent(event)
+            }
+        }
+    }
+
+    private func handleNodeEvent(_ frame: DecodedFrame) async {
+        switch frame {
+        case .selfInfo(_, let lat, let lon, _):
+            if let lat = lat, let lon = lon {
+                ownPosition = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+            }
+        case .nodeAdvert(let contactId, let name, let lat, let lon):
+            var c = contacts.first(where: { $0.id == contactId })
+                ?? MeshContact(id: contactId, name: name ?? contactId,
+                               lastSeen: nil, isOnline: false, lat: nil, lon: nil)
+            c.isOnline = true
+            c.lastSeen = Date()
+            if let name = name { c.name = name }
+            if let lat = lat { c.lat = lat }
+            if let lon = lon { c.lon = lon }
+            try? await contactStore.save(c)
+            upsert(c)
+        case .contact(let c):
+            try? await contactStore.save(c)
+            upsert(c)
+        case .contactsStart, .contactsEnd:
+            break
+        case .newChannelMessage, .newDirectMessage, .messageAck:
+            break
+        }
+    }
+
+    private func upsert(_ contact: MeshContact) {
+        if let idx = contacts.firstIndex(where: { $0.id == contact.id }) {
+            contacts[idx] = contact
+        } else {
+            contacts.append(contact)
+        }
+    }
+
+    deinit { listenerTask?.cancel() }
+}

--- a/MeshCoreMac/ViewModels/ContactsViewModel.swift
+++ b/MeshCoreMac/ViewModels/ContactsViewModel.swift
@@ -15,6 +15,7 @@ final class ContactsViewModel {
     nonisolated(unsafe) private var listenerTask: Task<Void, Never>?
     private var pendingContacts: [MeshContact] = []
     private var collectingContacts = false
+    private var started = false
 
     init(contactStore: ContactStore, bluetoothService: any BluetoothServiceProtocol) {
         self.contactStore = contactStore
@@ -22,6 +23,8 @@ final class ContactsViewModel {
     }
 
     func start() async {
+        guard !started else { return }
+        started = true
         contacts = (try? await contactStore.fetchAll()) ?? []
         startListening()
     }

--- a/MeshCoreMac/ViewModels/SidebarViewModel.swift
+++ b/MeshCoreMac/ViewModels/SidebarViewModel.swift
@@ -6,7 +6,6 @@ import Observation
 @Observable
 final class SidebarViewModel {
     var channels: [MeshChannel] = []
-    var contacts: [MeshContact] = []
     var selectedConversation: MeshMessage.Kind? = nil
 
     init() {
@@ -20,14 +19,6 @@ final class SidebarViewModel {
     func addChannel(_ channel: MeshChannel) {
         if !channels.contains(channel) {
             channels.append(channel)
-        }
-    }
-
-    func updateContact(_ contact: MeshContact) {
-        if let idx = contacts.firstIndex(where: { $0.id == contact.id }) {
-            contacts[idx] = contact
-        } else {
-            contacts.append(contact)
         }
     }
 

--- a/MeshCoreMac/Views/MainWindow/ChatView.swift
+++ b/MeshCoreMac/Views/MainWindow/ChatView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct ChatView: View {
     @Bindable var chatVM: ChatViewModel
     let conversation: MeshMessage.Kind
+    let contactsVM: ContactsViewModel
 
     var body: some View {
         VStack(spacing: 0) {
@@ -65,8 +66,10 @@ struct ChatView: View {
 
     private var conversationTitle: String {
         switch conversation {
-        case .channel(let idx): return "Kanal \(idx)"
-        case .direct(let cid):  return cid
+        case .channel(let idx):
+            return "Kanal \(idx)"
+        case .direct(let cid):
+            return contactsVM.contacts.first(where: { $0.id == cid })?.name ?? cid
         }
     }
 

--- a/MeshCoreMac/Views/MainWindow/ContactDetailView.swift
+++ b/MeshCoreMac/Views/MainWindow/ContactDetailView.swift
@@ -1,0 +1,59 @@
+// MeshCoreMac/Views/MainWindow/ContactDetailView.swift
+import SwiftUI
+
+struct ContactDetailView: View {
+    @State var contact: MeshContact
+    let onSave: (MeshContact) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        Form {
+            Section("Identität") {
+                LabeledContent("Node-ID", value: contact.id)
+                LabeledContent("Name") {
+                    TextField("Name", text: $contact.name)
+                        .multilineTextAlignment(.trailing)
+                }
+            }
+            Section("Status") {
+                LabeledContent("Online") {
+                    HStack {
+                        Circle()
+                            .fill(contact.isOnline ? Color.green : Color.red)
+                            .frame(width: 10, height: 10)
+                        Text(contact.isOnline ? "Ja" : "Nein")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if let lastSeen = contact.lastSeen {
+                    LabeledContent("Zuletzt gesehen",
+                                   value: lastSeen.formatted(date: .abbreviated, time: .shortened))
+                }
+            }
+            if contact.lat != nil || contact.lon != nil {
+                Section("Position") {
+                    if let lat = contact.lat {
+                        LabeledContent("Breite", value: String(format: "%.6f°", lat))
+                    }
+                    if let lon = contact.lon {
+                        LabeledContent("Länge", value: String(format: "%.6f°", lon))
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle(contact.name)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Abbrechen") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Sichern") {
+                    onSave(contact)
+                    dismiss()
+                }
+            }
+        }
+        .frame(minWidth: 320, minHeight: 280)
+    }
+}

--- a/MeshCoreMac/Views/MainWindow/MainWindowView.swift
+++ b/MeshCoreMac/Views/MainWindow/MainWindowView.swift
@@ -38,8 +38,8 @@ struct MainWindowView: View {
         NavigationSplitView {
             SidebarView(
                 sidebarVM: container.sidebarViewModel,
-                contactsVM: container.contactsViewModel,
-                connectionVM: container.connectionViewModel
+                connectionVM: container.connectionViewModel,
+                contactsVM: container.contactsViewModel
             )
             .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 280)
         } detail: {

--- a/MeshCoreMac/Views/MainWindow/MainWindowView.swift
+++ b/MeshCoreMac/Views/MainWindow/MainWindowView.swift
@@ -38,6 +38,7 @@ struct MainWindowView: View {
         NavigationSplitView {
             SidebarView(
                 sidebarVM: container.sidebarViewModel,
+                contactsVM: container.contactsViewModel,
                 connectionVM: container.connectionViewModel
             )
             .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 280)

--- a/MeshCoreMac/Views/MainWindow/MainWindowView.swift
+++ b/MeshCoreMac/Views/MainWindow/MainWindowView.swift
@@ -35,15 +35,12 @@ struct MainWindowView: View {
         }
         .sheet(isPresented: $showingMap) {
             NavigationStack {
-                NodeMapView(
-                    contacts: container.contactsViewModel.contacts,
-                    ownPosition: container.contactsViewModel.ownPosition
-                )
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Schließen") { showingMap = false }
+                MapSheetContent(contactsVM: container.contactsViewModel)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Schließen") { showingMap = false }
+                        }
                     }
-                }
             }
         }
     }
@@ -72,7 +69,7 @@ struct MainWindowView: View {
             }
         }
         .toolbar {
-            ToolbarItem(placement: .automatic) {
+            ToolbarItem(placement: .primaryAction) {
                 Button {
                     showingMap = true
                 } label: {
@@ -81,5 +78,13 @@ struct MainWindowView: View {
                 .help("Karte aller bekannten Nodes anzeigen")
             }
         }
+    }
+}
+
+// Observes ContactsViewModel directly so NodeMapView updates reactively.
+private struct MapSheetContent: View {
+    let contactsVM: ContactsViewModel
+    var body: some View {
+        NodeMapView(contacts: contactsVM.contacts, ownPosition: contactsVM.ownPosition)
     }
 }

--- a/MeshCoreMac/Views/MainWindow/MainWindowView.swift
+++ b/MeshCoreMac/Views/MainWindow/MainWindowView.swift
@@ -55,8 +55,8 @@ struct MainWindowView: View {
             .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 280)
         } detail: {
             if let conversation = container.sidebarViewModel.selectedConversation {
-                ChatView(
-                    chatVM: container.makeChatViewModel(for: conversation),
+                ChatContainer(
+                    container: container,
                     conversation: conversation,
                     contactsVM: container.contactsViewModel
                 )
@@ -86,5 +86,28 @@ private struct MapSheetContent: View {
     let contactsVM: ContactsViewModel
     var body: some View {
         NodeMapView(contacts: contactsVM.contacts, ownPosition: contactsVM.ownPosition)
+    }
+}
+
+// Holds a stable ChatViewModel per conversation via @State, preventing
+// re-creation on every MainWindowView body re-render.
+private struct ChatContainer: View {
+    let container: AppContainer
+    let conversation: MeshMessage.Kind
+    let contactsVM: ContactsViewModel
+
+    @State private var chatVM: ChatViewModel?
+
+    var body: some View {
+        Group {
+            if let chatVM {
+                ChatView(chatVM: chatVM, conversation: conversation, contactsVM: contactsVM)
+            } else {
+                ProgressView()
+            }
+        }
+        .task(id: conversation) {
+            chatVM = container.makeChatViewModel(for: conversation)
+        }
     }
 }

--- a/MeshCoreMac/Views/MainWindow/MainWindowView.swift
+++ b/MeshCoreMac/Views/MainWindow/MainWindowView.swift
@@ -5,6 +5,7 @@ struct MainWindowView: View {
     let container: AppContainer
 
     @State private var dismissedError: String? = nil
+    @State private var showingMap = false
 
     var body: some View {
         Group {
@@ -32,6 +33,19 @@ struct MainWindowView: View {
                 dismissedError = nil
             }
         }
+        .sheet(isPresented: $showingMap) {
+            NavigationStack {
+                NodeMapView(
+                    contacts: container.contactsViewModel.contacts,
+                    ownPosition: container.contactsViewModel.ownPosition
+                )
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Schließen") { showingMap = false }
+                    }
+                }
+            }
+        }
     }
 
     private var messengerView: some View {
@@ -46,7 +60,8 @@ struct MainWindowView: View {
             if let conversation = container.sidebarViewModel.selectedConversation {
                 ChatView(
                     chatVM: container.makeChatViewModel(for: conversation),
-                    conversation: conversation
+                    conversation: conversation,
+                    contactsVM: container.contactsViewModel
                 )
             } else {
                 ContentUnavailableView(
@@ -56,6 +71,15 @@ struct MainWindowView: View {
                 )
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    showingMap = true
+                } label: {
+                    Label("Karte", systemImage: "map")
+                }
+                .help("Karte aller bekannten Nodes anzeigen")
+            }
+        }
     }
-
 }

--- a/MeshCoreMac/Views/MainWindow/SidebarView.swift
+++ b/MeshCoreMac/Views/MainWindow/SidebarView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct SidebarView: View {
     let sidebarVM: SidebarViewModel
+    let contactsVM: ContactsViewModel
     let connectionVM: ConnectionViewModel
 
     var body: some View {
@@ -19,9 +20,9 @@ struct SidebarView: View {
                 }
             }
 
-            if !sidebarVM.contacts.isEmpty {
+            if !contactsVM.contacts.isEmpty {
                 Section("Direkt") {
-                    ForEach(sidebarVM.contacts) { contact in
+                    ForEach(contactsVM.contacts) { contact in
                         HStack {
                             Label(contact.name, systemImage: "person.fill")
                             Spacer()

--- a/MeshCoreMac/Views/MainWindow/SidebarView.swift
+++ b/MeshCoreMac/Views/MainWindow/SidebarView.swift
@@ -3,8 +3,10 @@ import SwiftUI
 
 struct SidebarView: View {
     let sidebarVM: SidebarViewModel
-    let contactsVM: ContactsViewModel
     let connectionVM: ConnectionViewModel
+    let contactsVM: ContactsViewModel
+
+    @State private var selectedContactForDetail: MeshContact? = nil
 
     var body: some View {
         List(selection: Binding(
@@ -25,12 +27,19 @@ struct SidebarView: View {
                     ForEach(contactsVM.contacts) { contact in
                         HStack {
                             Label(contact.name, systemImage: "person.fill")
+                                .tag(ConversationID(kind: .direct(contactId: contact.id)))
                             Spacer()
                             Circle()
                                 .fill(contact.isOnline ? Color.green : Color.red)
                                 .frame(width: 8, height: 8)
+                            Button {
+                                selectedContactForDetail = contact
+                            } label: {
+                                Image(systemName: "info.circle")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
                         }
-                        .tag(ConversationID(kind: .direct(contactId: contact.id)))
                     }
                 }
             }
@@ -48,6 +57,13 @@ struct SidebarView: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
+        }
+        .sheet(item: $selectedContactForDetail) { contact in
+            NavigationStack {
+                ContactDetailView(contact: contact) { updated in
+                    Task { await contactsVM.updateContact(updated) }
+                }
+            }
         }
     }
 }

--- a/MeshCoreMac/Views/Map/MapView.swift
+++ b/MeshCoreMac/Views/Map/MapView.swift
@@ -1,0 +1,62 @@
+// MeshCoreMac/Views/Map/MapView.swift
+import CoreLocation
+import MapKit
+import SwiftUI
+
+struct NodeMapView: View {
+    let contacts: [MeshContact]
+    let ownPosition: CLLocationCoordinate2D?
+
+    private var nodesWithPosition: [MeshContact] {
+        contacts.filter { $0.lat != nil && $0.lon != nil }
+    }
+
+    var body: some View {
+        Group {
+            if ownPosition == nil && nodesWithPosition.isEmpty {
+                emptyState
+            } else {
+                mapContent
+            }
+        }
+        .navigationTitle("Karte")
+        .frame(minWidth: 500, minHeight: 400)
+    }
+
+    private var mapContent: some View {
+        Map {
+            if let pos = ownPosition {
+                Annotation("Mein Node", coordinate: pos) {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .foregroundStyle(.white)
+                        .padding(6)
+                        .background(Color.blue, in: Circle())
+                }
+            }
+            ForEach(nodesWithPosition) { contact in
+                let coord = CLLocationCoordinate2D(
+                    latitude: contact.lat!,
+                    longitude: contact.lon!
+                )
+                Annotation(contact.name, coordinate: coord) {
+                    Image(systemName: "person.circle.fill")
+                        .foregroundStyle(.white)
+                        .padding(6)
+                        .background(
+                            contact.isOnline ? Color.green : Color.gray,
+                            in: Circle()
+                        )
+                }
+            }
+        }
+        .mapStyle(.standard(elevation: .flat))
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "Keine Positionen",
+            systemImage: "map",
+            description: Text("Warte auf GPS-Daten von Nodes in der Nähe.")
+        )
+    }
+}

--- a/MeshCoreMacTests/Services/ContactStoreTests.swift
+++ b/MeshCoreMacTests/Services/ContactStoreTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import MeshCoreMac
+
+@MainActor
+final class ContactStoreTests: XCTestCase {
+
+    func testSaveAndFetch_roundtripsAllFields() async throws {
+        let store = try ContactStore(inMemory: true)
+        let contact = MeshContact(id: "a1b2c3d4", name: "Alice",
+                                   lastSeen: nil, isOnline: true,
+                                   lat: 48.137, lon: 11.575)
+        try await store.save(contact)
+        let all = try await store.fetchAll()
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(all[0].id, "a1b2c3d4")
+        XCTAssertEqual(all[0].name, "Alice")
+        XCTAssertEqual(all[0].isOnline, true)
+        XCTAssertEqual(all[0].lat ?? 0, 48.137, accuracy: 0.0001)
+        XCTAssertEqual(all[0].lon ?? 0, 11.575, accuracy: 0.0001)
+    }
+
+    func testSave_upsertsByPrimaryKey() async throws {
+        let store = try ContactStore(inMemory: true)
+        var contact = MeshContact(id: "a1b2c3d4", name: "Bob",
+                                   lastSeen: nil, isOnline: false,
+                                   lat: nil, lon: nil)
+        try await store.save(contact)
+        contact.name = "Bob Updated"
+        contact.isOnline = true
+        contact.lat = 52.52
+        contact.lon = 13.405
+        try await store.save(contact)
+        let all = try await store.fetchAll()
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(all[0].name, "Bob Updated")
+        XCTAssertEqual(all[0].lat ?? 0, 52.52, accuracy: 0.001)
+    }
+
+    func testFetchById_returnsNilForMissing() async throws {
+        let store = try ContactStore(inMemory: true)
+        let result = try await store.fetch(id: "00000000")
+        XCTAssertNil(result)
+    }
+
+    func testFetchById_returnsContact() async throws {
+        let store = try ContactStore(inMemory: true)
+        let contact = MeshContact(id: "deadbeef", name: "Eve",
+                                   lastSeen: nil, isOnline: true,
+                                   lat: nil, lon: nil)
+        try await store.save(contact)
+        let fetched = try await store.fetch(id: "deadbeef")
+        XCTAssertEqual(fetched?.name, "Eve")
+    }
+
+    func testLastSeen_roundtrips() async throws {
+        let store = try ContactStore(inMemory: true)
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let contact = MeshContact(id: "aa11bb22", name: "Dave",
+                                   lastSeen: date, isOnline: false,
+                                   lat: nil, lon: nil)
+        try await store.save(contact)
+        let all = try await store.fetchAll()
+        let delta = abs((all[0].lastSeen?.timeIntervalSince1970 ?? 0) - 1_700_000_000)
+        XCTAssertLessThan(delta, 1.0)
+    }
+
+    func testDelete_removesContact() async throws {
+        let store = try ContactStore(inMemory: true)
+        let contact = MeshContact(id: "cafe1234", name: "Chuck",
+                                   lastSeen: nil, isOnline: false,
+                                   lat: nil, lon: nil)
+        try await store.save(contact)
+        try await store.delete(id: "cafe1234")
+        let all = try await store.fetchAll()
+        XCTAssert(all.isEmpty)
+    }
+}

--- a/MeshCoreMacTests/Services/ContactStoreTests.swift
+++ b/MeshCoreMacTests/Services/ContactStoreTests.swift
@@ -34,6 +34,7 @@ final class ContactStoreTests: XCTestCase {
         XCTAssertEqual(all.count, 1)
         XCTAssertEqual(all[0].name, "Bob Updated")
         XCTAssertEqual(all[0].lat ?? 0, 52.52, accuracy: 0.001)
+        XCTAssertTrue(all[0].isOnline)
     }
 
     func testFetchById_returnsNilForMissing() async throws {

--- a/MeshCoreMacTests/Services/MeshCoreProtocolServiceTests.swift
+++ b/MeshCoreMacTests/Services/MeshCoreProtocolServiceTests.swift
@@ -64,4 +64,93 @@ final class MeshCoreProtocolServiceTests: XCTestCase {
         let frame = Data([0xFF, 0x00])
         XCTAssertThrowsError(try MeshCoreProtocolService.decodeFrame(frame))
     }
+
+    func testEncodeGetContacts_hasSingleCommandByte() {
+        let frame = MeshCoreProtocolService.encodeGetContacts()
+        XCTAssertFalse(frame.isEmpty)
+        XCTAssertEqual(frame[0], MeshCoreProtocol.Command.getContacts.rawValue)
+    }
+
+    func testDecodeSelfInfo_parsesNodeIdAndPosition() throws {
+        // SELF_INFO payload: [pubkey:32][ts:4][lat_f32_le:4][lon_f32_le:4][alt:4][name]
+        var bytes = [UInt8](repeating: 0xAA, count: 32) // pubkey — first 4 bytes become nodeId
+        bytes += [0x00, 0x00, 0x00, 0x00]               // timestamp
+        // lat = 48.137  → Float32 little-endian
+        let latFloat = Float(48.137)
+        let latBits = latFloat.bitPattern
+        bytes += [UInt8(latBits & 0xFF), UInt8((latBits >> 8) & 0xFF),
+                  UInt8((latBits >> 16) & 0xFF), UInt8((latBits >> 24) & 0xFF)]
+        // lon = 11.575
+        let lonFloat = Float(11.575)
+        let lonBits = lonFloat.bitPattern
+        bytes += [UInt8(lonBits & 0xFF), UInt8((lonBits >> 8) & 0xFF),
+                  UInt8((lonBits >> 16) & 0xFF), UInt8((lonBits >> 24) & 0xFF)]
+        bytes += [0x00, 0x00, 0x00, 0x00]               // alt
+        bytes += Array("MyNode".utf8)
+        var frame = [MeshCoreProtocol.Response.selfInfo.rawValue]
+        frame += bytes
+        let decoded = try MeshCoreProtocolService.decodeFrame(Data(frame))
+        guard case .selfInfo(let nodeId, let lat, let lon, let firmware) = decoded else {
+            return XCTFail("Expected .selfInfo, got \(decoded)")
+        }
+        XCTAssertEqual(nodeId, "aaaaaaaa")
+        XCTAssertEqual(lat ?? 0, 48.137, accuracy: 0.01)
+        XCTAssertEqual(lon ?? 0, 11.575, accuracy: 0.01)
+        XCTAssertEqual(firmware, "MyNode")
+    }
+
+    func testDecodeAdvert_parsesContactIdAndPosition() throws {
+        // ADVERT payload same format as SELF_INFO
+        var bytes = [UInt8](repeating: 0xBB, count: 32) // pubkey
+        bytes += [0x00, 0x00, 0x00, 0x00]               // timestamp
+        let latFloat = Float(52.52)
+        let latBits = latFloat.bitPattern
+        bytes += [UInt8(latBits & 0xFF), UInt8((latBits >> 8) & 0xFF),
+                  UInt8((latBits >> 16) & 0xFF), UInt8((latBits >> 24) & 0xFF)]
+        let lonFloat = Float(13.405)
+        let lonBits = lonFloat.bitPattern
+        bytes += [UInt8(lonBits & 0xFF), UInt8((lonBits >> 8) & 0xFF),
+                  UInt8((lonBits >> 16) & 0xFF), UInt8((lonBits >> 24) & 0xFF)]
+        bytes += [0x00, 0x00, 0x00, 0x00]               // alt
+        bytes += Array("Berlin".utf8) + [0x00]          // NUL-terminated name
+        var frame = [MeshCoreProtocol.Push.advert.rawValue]
+        frame += bytes
+        let decoded = try MeshCoreProtocolService.decodeFrame(Data(frame))
+        guard case .nodeAdvert(let contactId, let name, let lat, let lon) = decoded else {
+            return XCTFail("Expected .nodeAdvert, got \(decoded)")
+        }
+        XCTAssertEqual(contactId, "bbbbbbbb")
+        XCTAssertEqual(name, "Berlin")
+        XCTAssertEqual(lat ?? 0, 52.52, accuracy: 0.01)
+        XCTAssertEqual(lon ?? 0, 13.405, accuracy: 0.01)
+    }
+
+    func testDecodeContact_parsesNameAndOnlineFlag() throws {
+        // CONTACT payload: [pubkey:32][last_heard:4][flags:1][name:variable]
+        var bytes = [UInt8](repeating: 0xCC, count: 32) // pubkey
+        bytes += [0x00, 0x00, 0x00, 0x00]               // last_heard
+        bytes += [0x01]                                  // flags: bit0 = online
+        bytes += Array("Charlie".utf8)
+        var frame = [MeshCoreProtocol.Response.contact.rawValue]
+        frame += bytes
+        let decoded = try MeshCoreProtocolService.decodeFrame(Data(frame))
+        guard case .contact(let c) = decoded else {
+            return XCTFail("Expected .contact, got \(decoded)")
+        }
+        XCTAssertEqual(c.id, "cccccccc")
+        XCTAssertEqual(c.name, "Charlie")
+        XCTAssertTrue(c.isOnline)
+    }
+
+    func testDecodeContactsEnd_returnsContactsEnd() throws {
+        let frame = Data([MeshCoreProtocol.Response.endOfContacts.rawValue])
+        let decoded = try MeshCoreProtocolService.decodeFrame(frame)
+        XCTAssertEqual(decoded, .contactsEnd)
+    }
+
+    func testDecodeContactsStart_returnsContactsStart() throws {
+        let frame = Data([MeshCoreProtocol.Response.contactsStart.rawValue])
+        let decoded = try MeshCoreProtocolService.decodeFrame(frame)
+        XCTAssertEqual(decoded, .contactsStart)
+    }
 }

--- a/MeshCoreMacTests/Services/MockBluetoothService.swift
+++ b/MeshCoreMacTests/Services/MockBluetoothService.swift
@@ -15,6 +15,8 @@ final class MockBluetoothService: BluetoothServiceProtocol {
     var discoveredDevices: [CBPeripheral] = []
     let incomingFrames: AsyncStream<Data>
     private let frameContinuation: AsyncStream<Data>.Continuation
+    let nodeEventStream: AsyncStream<DecodedFrame>
+    private let nodeEventContinuation: AsyncStream<DecodedFrame>.Continuation
 
     var sentFrames: [Data] = []
     var scanStarted = false
@@ -24,6 +26,9 @@ final class MockBluetoothService: BluetoothServiceProtocol {
         let (stream, continuation) = AsyncStream<Data>.makeStream()
         self.incomingFrames = stream
         self.frameContinuation = continuation
+        let (nodeStream, nodeCont) = AsyncStream<DecodedFrame>.makeStream()
+        self.nodeEventStream = nodeStream
+        self.nodeEventContinuation = nodeCont
     }
 
     func startScanning() { scanStarted = true }
@@ -45,6 +50,10 @@ final class MockBluetoothService: BluetoothServiceProtocol {
 
     func simulateIncomingFrame(_ data: Data) {
         frameContinuation.yield(data)
+    }
+
+    func simulateNodeEvent(_ frame: DecodedFrame) {
+        nodeEventContinuation.yield(frame)
     }
 
     func simulateDisconnect() {

--- a/MeshCoreMacTests/Services/MockBluetoothService.swift
+++ b/MeshCoreMacTests/Services/MockBluetoothService.swift
@@ -63,4 +63,9 @@ final class MockBluetoothService: BluetoothServiceProtocol {
     func simulateConnect(peripheralName: String = "Mock-Node") {
         connectionState = .ready(peripheralName: peripheralName)
     }
+
+    deinit {
+        frameContinuation.finish()
+        nodeEventContinuation.finish()
+    }
 }

--- a/MeshCoreMacTests/ViewModels/ContactsViewModelTests.swift
+++ b/MeshCoreMacTests/ViewModels/ContactsViewModelTests.swift
@@ -91,6 +91,50 @@ final class ContactsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.contacts.first?.name, "Dave Updated")
     }
 
+    func testStart_calledTwice_doesNotOverwriteLiveContacts() async throws {
+        mockBluetooth.simulateNodeEvent(
+            .nodeAdvert(contactId: "a1b2c3d4", name: "Alice", lat: nil, lon: nil)
+        )
+        try await waitUntil { !self.vm.contacts.isEmpty }
+        XCTAssertEqual(vm.contacts.count, 1)
+
+        await vm.start()
+        XCTAssertEqual(vm.contacts.count, 1, "Second start() call must be a no-op")
+    }
+
+    func testContactsEnd_withoutStart_isNoOp() async throws {
+        let contact = MeshContact(id: "a1b2c3d4", name: "Alice",
+                                   lastSeen: nil, isOnline: true,
+                                   lat: nil, lon: nil)
+        mockBluetooth.simulateNodeEvent(.contact(contact))
+        try await waitUntil { !self.vm.contacts.isEmpty }
+        XCTAssertEqual(vm.contacts.count, 1)
+
+        mockBluetooth.simulateNodeEvent(.contactsEnd)
+        try await Task.sleep(for: .milliseconds(20))
+        XCTAssertEqual(vm.contacts.count, 1, "contactsEnd without contactsStart must not clear contacts")
+    }
+
+    func testContactsStart_twice_resetsBuffer() async throws {
+        mockBluetooth.simulateNodeEvent(.contactsStart)
+        let c1 = MeshContact(id: "a1b2c3d4", name: "Alice",
+                              lastSeen: nil, isOnline: true, lat: nil, lon: nil)
+        mockBluetooth.simulateNodeEvent(.contact(c1))
+        try await Task.sleep(for: .milliseconds(20))
+
+        mockBluetooth.simulateNodeEvent(.contactsStart)
+        let c2 = MeshContact(id: "b2c3d4e5", name: "Bob",
+                              lastSeen: nil, isOnline: true, lat: nil, lon: nil)
+        mockBluetooth.simulateNodeEvent(.contact(c2))
+        mockBluetooth.simulateNodeEvent(.contactsEnd)
+        try await waitUntil { self.vm.contacts.contains(where: { $0.id == "b2c3d4e5" }) }
+
+        XCTAssertFalse(vm.contacts.contains(where: { $0.id == "a1b2c3d4" }),
+                       "Second contactsStart must discard first buffer (Alice not persisted yet)")
+        XCTAssertTrue(vm.contacts.contains(where: { $0.id == "b2c3d4e5" }),
+                      "Bob from second sequence must be present")
+    }
+
     // MARK: - Helper
 
     private func waitUntil(

--- a/MeshCoreMacTests/ViewModels/ContactsViewModelTests.swift
+++ b/MeshCoreMacTests/ViewModels/ContactsViewModelTests.swift
@@ -1,3 +1,4 @@
+// MeshCoreMacTests/ViewModels/ContactsViewModelTests.swift
 import XCTest
 import CoreLocation
 @testable import MeshCoreMac
@@ -67,7 +68,8 @@ final class ContactsViewModelTests: XCTestCase {
                                    lat: nil, lon: nil)
         try await contactStore.save(contact)
 
-        let newVM = ContactsViewModel(contactStore: contactStore, bluetoothService: mockBluetooth)
+        let isolatedMock = MockBluetoothService()
+        let newVM = ContactsViewModel(contactStore: contactStore, bluetoothService: isolatedMock)
         await newVM.start()
 
         XCTAssertEqual(newVM.contacts.count, 1)
@@ -101,7 +103,7 @@ final class ContactsViewModelTests: XCTestCase {
                 XCTFail("Timeout waiting for condition")
                 return
             }
-            await Task.yield()
+            try await Task.sleep(for: .milliseconds(10))
         }
     }
 }

--- a/MeshCoreMacTests/ViewModels/ContactsViewModelTests.swift
+++ b/MeshCoreMacTests/ViewModels/ContactsViewModelTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+import CoreLocation
+@testable import MeshCoreMac
+
+@MainActor
+final class ContactsViewModelTests: XCTestCase {
+
+    var mockBluetooth: MockBluetoothService!
+    var contactStore: ContactStore!
+    var vm: ContactsViewModel!
+
+    override func setUp() async throws {
+        mockBluetooth = MockBluetoothService()
+        contactStore = try ContactStore(inMemory: true)
+        vm = ContactsViewModel(contactStore: contactStore, bluetoothService: mockBluetooth)
+        await vm.start()
+    }
+
+    override func tearDown() async throws {
+        vm = nil
+        contactStore = nil
+        mockBluetooth = nil
+    }
+
+    func testNodeAdvert_addsContactToList() async throws {
+        mockBluetooth.simulateNodeEvent(
+            .nodeAdvert(contactId: "a1b2c3d4", name: "Alice", lat: 48.137, lon: 11.575)
+        )
+        try await waitUntil { !self.vm.contacts.isEmpty }
+        XCTAssertEqual(vm.contacts.count, 1)
+        XCTAssertEqual(vm.contacts[0].name, "Alice")
+        XCTAssertTrue(vm.contacts[0].isOnline)
+        XCTAssertEqual(vm.contacts[0].lat ?? 0, 48.137, accuracy: 0.001)
+    }
+
+    func testNodeAdvert_persistsToStore() async throws {
+        mockBluetooth.simulateNodeEvent(
+            .nodeAdvert(contactId: "a1b2c3d4", name: "Alice", lat: nil, lon: nil)
+        )
+        try await waitUntil { !self.vm.contacts.isEmpty }
+        let stored = try await contactStore.fetchAll()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored[0].name, "Alice")
+    }
+
+    func testContactEvent_addsToList() async throws {
+        let contact = MeshContact(id: "dead1234", name: "Bob",
+                                   lastSeen: nil, isOnline: true,
+                                   lat: nil, lon: nil)
+        mockBluetooth.simulateNodeEvent(.contact(contact))
+        try await waitUntil { !self.vm.contacts.isEmpty }
+        XCTAssertEqual(vm.contacts[0].name, "Bob")
+    }
+
+    func testSelfInfo_setsOwnPosition() async throws {
+        mockBluetooth.simulateNodeEvent(
+            .selfInfo(nodeId: "aa11bb22", lat: 52.52, lon: 13.405, firmware: "v1.0")
+        )
+        try await waitUntil { self.vm.ownPosition != nil }
+        XCTAssertEqual(vm.ownPosition?.latitude ?? 0, 52.52, accuracy: 0.001)
+        XCTAssertEqual(vm.ownPosition?.longitude ?? 0, 13.405, accuracy: 0.001)
+    }
+
+    func testStart_loadsPersistedContacts() async throws {
+        let contact = MeshContact(id: "cafe1234", name: "Charlie",
+                                   lastSeen: nil, isOnline: false,
+                                   lat: nil, lon: nil)
+        try await contactStore.save(contact)
+
+        let newVM = ContactsViewModel(contactStore: contactStore, bluetoothService: mockBluetooth)
+        await newVM.start()
+
+        XCTAssertEqual(newVM.contacts.count, 1)
+        XCTAssertEqual(newVM.contacts[0].name, "Charlie")
+    }
+
+    func testUpdateContact_persistsNameChange() async throws {
+        var contact = MeshContact(id: "aa11bb22", name: "Dave",
+                                   lastSeen: nil, isOnline: false,
+                                   lat: nil, lon: nil)
+        mockBluetooth.simulateNodeEvent(.contact(contact))
+        try await waitUntil { !self.vm.contacts.isEmpty }
+
+        contact.name = "Dave Updated"
+        await vm.updateContact(contact)
+
+        let stored = try await contactStore.fetchAll()
+        XCTAssertEqual(stored.first?.name, "Dave Updated")
+        XCTAssertEqual(vm.contacts.first?.name, "Dave Updated")
+    }
+
+    // MARK: - Helper
+
+    private func waitUntil(
+        timeout: TimeInterval = 1.0,
+        condition: @escaping () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            guard Date() < deadline else {
+                XCTFail("Timeout waiting for condition")
+                return
+            }
+            await Task.yield()
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-05-01-meshcoremac-phase2.md
+++ b/docs/superpowers/plans/2026-05-01-meshcoremac-phase2.md
@@ -1,0 +1,1873 @@
+# MeshCoreMac Phase 2 — Kontakte & Karte
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Contacts persisted from MeshCore protocol events (ADVERT, GET_CONTACTS, SELF_INFO) with editable names, an online/last-seen indicator, and a MapKit map showing node positions.
+
+**Architecture:** ContactStore (GRDB) owns contact persistence. ContactsViewModel subscribes to a new `nodeEventStream: AsyncStream<DecodedFrame>` on BluetoothService, updating in-memory contacts and the store. SidebarView and ChatView read contacts from ContactsViewModel. DecodedFrame gets richer cases that carry lat/lon and contact list data decoded from real MeshCore frames.
+
+**Tech Stack:** Swift 6 strict concurrency, SwiftUI + MVVM + `@Observable`, CoreBluetooth, GRDB 6, MapKit (SwiftUI `Map`), XCTest
+
+---
+
+## Existing Codebase Context
+
+Read these files before starting any task — they define the interfaces every task builds on:
+
+- `MeshCoreMac/Services/MeshCoreProtocol.swift` — DecodedFrame, Command/Response enums
+- `MeshCoreMac/Services/BluetoothServiceProtocol.swift` — protocol that MockBluetoothService implements
+- `MeshCoreMac/Services/MeshCoreBluetoothService.swift` — BLE service, see `sendInitSequence()` and `didUpdateValueFor`
+- `MeshCoreMac/ViewModels/ChatViewModel.swift` — `handleFrame` switch must stay exhaustive over DecodedFrame
+- `MeshCoreMac/Views/MainWindow/MainWindowView.swift` — passes `container.*` to SidebarView and ChatView
+- `MeshCoreMacTests/Services/MockBluetoothService.swift` — mock used by all ViewModel tests
+
+**Key invariants to preserve:**
+- `incomingFrames: AsyncStream<Data>` on BluetoothService stays **unchanged** — ChatViewModel still consumes raw bytes
+- All Swift 6 strict concurrency rules: `@MainActor` on ViewModels, `nonisolated(unsafe)` for Task properties in deinit, `@preconcurrency` for CB delegates
+- Tests use `XCTest` / `XCTestCase`, `@MainActor` on class, `override func setUp() async throws`
+- `nonisolated deinit` pattern: `nonisolated(unsafe) private var listenerTask: Task<Void, Never>?` then `deinit { listenerTask?.cancel() }`
+
+---
+
+## File Structure
+
+```
+New files:
+  MeshCoreMac/Services/ContactRecord.swift            — GRDB FetchableRecord/PersistableRecord for MeshContact
+  MeshCoreMac/Services/ContactStore.swift             — GRDB-backed contact persistence (mirrors MessageStore)
+  MeshCoreMac/ViewModels/ContactsViewModel.swift      — @Observable, consumes nodeEventStream, owns contact list
+  MeshCoreMac/Views/MainWindow/ContactDetailView.swift — editable name, lat/lon, lastSeen, online badge
+  MeshCoreMac/Views/Map/MapView.swift                 — SwiftUI Map with Marker per node
+  MeshCoreMacTests/Services/ContactStoreTests.swift
+  MeshCoreMacTests/ViewModels/ContactsViewModelTests.swift
+
+Modified files:
+  MeshCoreMac/Models/MeshContact.swift                — add lat: Double?, lon: Double?
+  MeshCoreMac/Services/MeshCoreProtocol.swift         — rename DecodedFrame cases, add new cases, add encodeGetContacts
+  MeshCoreMac/Services/MeshCoreProtocolService.swift  — decode ADVERT/SELF_INFO with position, decode CONTACT list
+  MeshCoreMac/Services/BluetoothServiceProtocol.swift — add nodeEventStream
+  MeshCoreMac/Services/MeshCoreBluetoothService.swift — add nodeEventStream, routing, send GET_CONTACTS
+  MeshCoreMacTests/Services/MockBluetoothService.swift — add nodeEventStream + simulateNodeEvent
+  MeshCoreMac/ViewModels/ChatViewModel.swift          — update handleFrame switch for renamed/new DecodedFrame cases
+  MeshCoreMac/ViewModels/SidebarViewModel.swift       — remove contacts/updateContact (owned by ContactsViewModel)
+  MeshCoreMac/App/AppContainer.swift                  — add contactStore, contactsViewModel
+  MeshCoreMac/Views/MainWindow/SidebarView.swift      — use contactsVM.contacts, add contact detail sheet
+  MeshCoreMac/Views/MainWindow/ChatView.swift         — add contactsVM param for DM title resolution
+  MeshCoreMac/Views/MainWindow/MainWindowView.swift   — pass contactsVM, add Map toolbar button
+```
+
+---
+
+## Task 1: Extended MeshContact + ContactRecord + ContactStore
+
+**Files:**
+- Modify: `MeshCoreMac/Models/MeshContact.swift`
+- Create: `MeshCoreMac/Services/ContactRecord.swift`
+- Create: `MeshCoreMac/Services/ContactStore.swift`
+- Create: `MeshCoreMacTests/Services/ContactStoreTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `MeshCoreMacTests/Services/ContactStoreTests.swift`:
+
+```swift
+import XCTest
+@testable import MeshCoreMac
+
+@MainActor
+final class ContactStoreTests: XCTestCase {
+
+    func testSaveAndFetch_roundtripsAllFields() async throws {
+        let store = try ContactStore(inMemory: true)
+        let contact = MeshContact(id: "a1b2c3d4", name: "Alice",
+                                   lastSeen: nil, isOnline: true,
+                                   lat: 48.137, lon: 11.575)
+        try await store.save(contact)
+        let all = try await store.fetchAll()
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(all[0].id, "a1b2c3d4")
+        XCTAssertEqual(all[0].name, "Alice")
+        XCTAssertEqual(all[0].isOnline, true)
+        XCTAssertEqual(all[0].lat ?? 0, 48.137, accuracy: 0.0001)
+        XCTAssertEqual(all[0].lon ?? 0, 11.575, accuracy: 0.0001)
+    }
+
+    func testSave_upsertsByPrimaryKey() async throws {
+        let store = try ContactStore(inMemory: true)
+        var contact = MeshContact(id: "a1b2c3d4", name: "Bob",
+                                   lastSeen: nil, isOnline: false,
+                                   lat: nil, lon: nil)
+        try await store.save(contact)
+        contact.name = "Bob Updated"
+        contact.isOnline = true
+        contact.lat = 52.52
+        contact.lon = 13.405
+        try await store.save(contact)
+        let all = try await store.fetchAll()
+        XCTAssertEqual(all.count, 1)
+        XCTAssertEqual(all[0].name, "Bob Updated")
+        XCTAssertEqual(all[0].lat ?? 0, 52.52, accuracy: 0.001)
+    }
+
+    func testFetchById_returnsNilForMissing() async throws {
+        let store = try ContactStore(inMemory: true)
+        let result = try await store.fetch(id: "00000000")
+        XCTAssertNil(result)
+    }
+
+    func testFetchById_returnsContact() async throws {
+        let store = try ContactStore(inMemory: true)
+        let contact = MeshContact(id: "deadbeef", name: "Eve",
+                                   lastSeen: nil, isOnline: true,
+                                   lat: nil, lon: nil)
+        try await store.save(contact)
+        let fetched = try await store.fetch(id: "deadbeef")
+        XCTAssertEqual(fetched?.name, "Eve")
+    }
+
+    func testLastSeen_roundtrips() async throws {
+        let store = try ContactStore(inMemory: true)
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let contact = MeshContact(id: "aa11bb22", name: "Dave",
+                                   lastSeen: date, isOnline: false,
+                                   lat: nil, lon: nil)
+        try await store.save(contact)
+        let all = try await store.fetchAll()
+        let delta = abs((all[0].lastSeen?.timeIntervalSince1970 ?? 0) - 1_700_000_000)
+        XCTAssertLessThan(delta, 1.0)
+    }
+
+    func testDelete_removesContact() async throws {
+        let store = try ContactStore(inMemory: true)
+        let contact = MeshContact(id: "cafe1234", name: "Chuck",
+                                   lastSeen: nil, isOnline: false,
+                                   lat: nil, lon: nil)
+        try await store.save(contact)
+        try await store.delete(id: "cafe1234")
+        let all = try await store.fetchAll()
+        XCTAssert(all.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/jarodschilke/Projekte/MeshCoreMacApp
+xcodegen generate
+xcodebuild test -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' \
+  -only-testing:MeshCoreMacTests/ContactStoreTests 2>&1 | tail -30
+```
+
+Expected: compile error — `ContactStore`, `MeshContact.lat` not found.
+
+- [ ] **Step 3: Extend MeshContact**
+
+Replace `MeshCoreMac/Models/MeshContact.swift` with:
+
+```swift
+import Foundation
+
+struct MeshContact: Identifiable, Hashable, Sendable {
+    let id: String     // Hex-Node-Adresse (z.B. "a1b2c3d4")
+    var name: String
+    var lastSeen: Date?
+    var isOnline: Bool
+    var lat: Double?
+    var lon: Double?
+}
+```
+
+- [ ] **Step 4: Create ContactRecord**
+
+Create `MeshCoreMac/Services/ContactRecord.swift`:
+
+```swift
+import GRDB
+import Foundation
+
+struct ContactRecord: Codable, FetchableRecord, PersistableRecord {
+    static let databaseTableName = "contacts"
+
+    var id: String
+    var name: String
+    var lastSeen: Double?   // Date.timeIntervalSince1970
+    var isOnline: Bool
+    var lat: Double?
+    var lon: Double?
+
+    init(from contact: MeshContact) {
+        id = contact.id
+        name = contact.name
+        lastSeen = contact.lastSeen?.timeIntervalSince1970
+        isOnline = contact.isOnline
+        lat = contact.lat
+        lon = contact.lon
+    }
+
+    func toMeshContact() -> MeshContact {
+        MeshContact(
+            id: id,
+            name: name,
+            lastSeen: lastSeen.map { Date(timeIntervalSince1970: $0) },
+            isOnline: isOnline,
+            lat: lat,
+            lon: lon
+        )
+    }
+}
+```
+
+- [ ] **Step 5: Create ContactStore**
+
+Create `MeshCoreMac/Services/ContactStore.swift`:
+
+```swift
+import GRDB
+import Foundation
+
+final class ContactStore: Sendable {
+    private let dbQueue: DatabaseQueue
+
+    init(inMemory: Bool = false) throws {
+        if inMemory {
+            dbQueue = try DatabaseQueue()
+        } else {
+            let appSupport = try FileManager.default.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+            let dbURL = appSupport
+                .appendingPathComponent("MeshCoreMac", isDirectory: true)
+                .appendingPathComponent("contacts.sqlite")
+            try FileManager.default.createDirectory(
+                at: dbURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            dbQueue = try DatabaseQueue(path: dbURL.path)
+        }
+        try runMigrations()
+    }
+
+    private func runMigrations() throws {
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration("v1_create_contacts") { db in
+            try db.create(table: ContactRecord.databaseTableName, ifNotExists: true) { t in
+                t.column("id", .text).primaryKey()
+                t.column("name", .text).notNull()
+                t.column("lastSeen", .double)
+                t.column("isOnline", .boolean).notNull()
+                t.column("lat", .double)
+                t.column("lon", .double)
+            }
+        }
+        try migrator.migrate(dbQueue)
+    }
+
+    func save(_ contact: MeshContact) async throws {
+        let record = ContactRecord(from: contact)
+        try await dbQueue.write { db in
+            try record.save(db)
+        }
+    }
+
+    func fetchAll() async throws -> [MeshContact] {
+        try await dbQueue.read { db in
+            try ContactRecord.fetchAll(db).map { $0.toMeshContact() }
+        }
+    }
+
+    func fetch(id: String) async throws -> MeshContact? {
+        try await dbQueue.read { db in
+            try ContactRecord.fetchOne(db, key: id)?.toMeshContact()
+        }
+    }
+
+    func delete(id: String) async throws {
+        try await dbQueue.write { db in
+            _ = try ContactRecord.deleteOne(db, key: id)
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run tests — expect all 6 to pass**
+
+```bash
+xcodebuild test -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' \
+  -only-testing:MeshCoreMacTests/ContactStoreTests 2>&1 | tail -20
+```
+
+Expected: `** TEST SUCCEEDED **`, 6 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add MeshCoreMac/Models/MeshContact.swift \
+        MeshCoreMac/Services/ContactRecord.swift \
+        MeshCoreMac/Services/ContactStore.swift \
+        MeshCoreMacTests/Services/ContactStoreTests.swift
+git commit -m "feat: extend MeshContact with lat/lon, add ContactRecord + ContactStore (GRDB)"
+```
+
+---
+
+## Task 2: Protocol Extensions — DecodedFrame + Decode Logic
+
+This task renames two existing DecodedFrame cases, adds new ones, extends decode logic to extract lat/lon from real MeshCore wire format, and adds `encodeGetContacts()`. ChatViewModel's switch must be updated for compilation.
+
+**MeshCore wire format used in this task:**
+- **ADVERT (0x80) / SELF_INFO (0x05) payload:** `[pubkey:32][timestamp_le4][lat_f32_le4][lon_f32_le4][alt_f32_le4][name:variable_utf8_nulterminated]` — minimum 48 bytes
+- **CONTACT response (0x03) payload:** `[pubkey:32][last_heard_le4][flags:1][name:variable_utf8]` — minimum 37 bytes
+- **CONTACTS_START (0x02):** no payload relevant
+- **END_OF_CONTACTS (0x04):** no payload relevant
+
+**Files:**
+- Modify: `MeshCoreMac/Services/MeshCoreProtocol.swift`
+- Modify: `MeshCoreMac/Services/MeshCoreProtocolService.swift`
+- Modify: `MeshCoreMac/ViewModels/ChatViewModel.swift`
+- Modify: `MeshCoreMacTests/Services/MeshCoreProtocolServiceTests.swift`
+
+- [ ] **Step 1: Add tests for new decode behavior**
+
+Append to `MeshCoreMacTests/Services/MeshCoreProtocolServiceTests.swift` (inside the class body, before the closing `}`):
+
+```swift
+    func testEncodeGetContacts_hasSingleCommandByte() {
+        let frame = MeshCoreProtocolService.encodeGetContacts()
+        XCTAssertFalse(frame.isEmpty)
+        XCTAssertEqual(frame[0], MeshCoreProtocol.Command.getContacts.rawValue)
+    }
+
+    func testDecodeSelfInfo_parsesNodeIdAndPosition() throws {
+        // SELF_INFO payload: [pubkey:32][ts:4][lat_f32_le:4][lon_f32_le:4][alt:4][name]
+        var bytes = [UInt8](repeating: 0xAA, count: 32) // pubkey — first 4 bytes become nodeId
+        bytes += [0x00, 0x00, 0x00, 0x00]               // timestamp
+        // lat = 48.137  → Float32 little-endian
+        let latFloat = Float(48.137)
+        let latBits = latFloat.bitPattern
+        bytes += [UInt8(latBits & 0xFF), UInt8((latBits >> 8) & 0xFF),
+                  UInt8((latBits >> 16) & 0xFF), UInt8((latBits >> 24) & 0xFF)]
+        // lon = 11.575
+        let lonFloat = Float(11.575)
+        let lonBits = lonFloat.bitPattern
+        bytes += [UInt8(lonBits & 0xFF), UInt8((lonBits >> 8) & 0xFF),
+                  UInt8((lonBits >> 16) & 0xFF), UInt8((lonBits >> 24) & 0xFF)]
+        bytes += [0x00, 0x00, 0x00, 0x00]               // alt
+        bytes += Array("MyNode".utf8)
+        var frame = [MeshCoreProtocol.Response.selfInfo.rawValue]
+        frame += bytes
+        let decoded = try MeshCoreProtocolService.decodeFrame(Data(frame))
+        guard case .selfInfo(let nodeId, let lat, let lon, let firmware) = decoded else {
+            return XCTFail("Expected .selfInfo, got \(decoded)")
+        }
+        XCTAssertEqual(nodeId, "aaaaaaaa")
+        XCTAssertEqual(lat ?? 0, 48.137, accuracy: 0.01)
+        XCTAssertEqual(lon ?? 0, 11.575, accuracy: 0.01)
+        XCTAssertEqual(firmware, "MyNode")
+    }
+
+    func testDecodeAdvert_parsesContactIdAndPosition() throws {
+        // ADVERT payload same format as SELF_INFO
+        var bytes = [UInt8](repeating: 0xBB, count: 32) // pubkey
+        bytes += [0x00, 0x00, 0x00, 0x00]               // timestamp
+        let latFloat = Float(52.52)
+        let latBits = latFloat.bitPattern
+        bytes += [UInt8(latBits & 0xFF), UInt8((latBits >> 8) & 0xFF),
+                  UInt8((latBits >> 16) & 0xFF), UInt8((latBits >> 24) & 0xFF)]
+        let lonFloat = Float(13.405)
+        let lonBits = lonFloat.bitPattern
+        bytes += [UInt8(lonBits & 0xFF), UInt8((lonBits >> 8) & 0xFF),
+                  UInt8((lonBits >> 16) & 0xFF), UInt8((lonBits >> 24) & 0xFF)]
+        bytes += [0x00, 0x00, 0x00, 0x00]               // alt
+        bytes += Array("Berlin".utf8) + [0x00]          // NUL-terminated name
+        var frame = [MeshCoreProtocol.Push.advert.rawValue]
+        frame += bytes
+        let decoded = try MeshCoreProtocolService.decodeFrame(Data(frame))
+        guard case .nodeAdvert(let contactId, let name, let lat, let lon) = decoded else {
+            return XCTFail("Expected .nodeAdvert, got \(decoded)")
+        }
+        XCTAssertEqual(contactId, "bbbbbbbb")
+        XCTAssertEqual(name, "Berlin")
+        XCTAssertEqual(lat ?? 0, 52.52, accuracy: 0.01)
+        XCTAssertEqual(lon ?? 0, 13.405, accuracy: 0.01)
+    }
+
+    func testDecodeContact_parsesNameAndOnlineFlag() throws {
+        // CONTACT payload: [pubkey:32][last_heard:4][flags:1][name:variable]
+        var bytes = [UInt8](repeating: 0xCC, count: 32) // pubkey
+        bytes += [0x00, 0x00, 0x00, 0x00]               // last_heard
+        bytes += [0x01]                                  // flags: bit0 = online
+        bytes += Array("Charlie".utf8)
+        var frame = [MeshCoreProtocol.Response.contact.rawValue]
+        frame += bytes
+        let decoded = try MeshCoreProtocolService.decodeFrame(Data(frame))
+        guard case .contact(let c) = decoded else {
+            return XCTFail("Expected .contact, got \(decoded)")
+        }
+        XCTAssertEqual(c.id, "cccccccc")
+        XCTAssertEqual(c.name, "Charlie")
+        XCTAssertTrue(c.isOnline)
+    }
+
+    func testDecodeContactsEnd_returnsContactsEnd() throws {
+        let frame = Data([MeshCoreProtocol.Response.endOfContacts.rawValue])
+        let decoded = try MeshCoreProtocolService.decodeFrame(frame)
+        XCTAssertEqual(decoded, .contactsEnd)
+    }
+
+    func testDecodeContactsStart_returnsContactsStart() throws {
+        let frame = Data([MeshCoreProtocol.Response.contactsStart.rawValue])
+        let decoded = try MeshCoreProtocolService.decodeFrame(frame)
+        XCTAssertEqual(decoded, .contactsStart)
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+xcodebuild test -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' \
+  -only-testing:MeshCoreMacTests/MeshCoreProtocolServiceTests 2>&1 | tail -30
+```
+
+Expected: compile error — new cases don't exist yet.
+
+- [ ] **Step 3: Update DecodedFrame in MeshCoreProtocol.swift**
+
+Replace the `DecodedFrame` enum section (starting at `// MARK: - Decoded Frame Typen`) with:
+
+```swift
+// MARK: - Decoded Frame Typen
+
+/// Strukturiertes Ergebnis nach erfolgreichem Frame-Decode.
+enum DecodedFrame: Sendable, Equatable {
+    /// Eigene Node-Info mit optionaler GPS-Position (SELF_INFO 0x05, DEVICE_INFO 0x0D).
+    case selfInfo(nodeId: String, lat: Double?, lon: Double?, firmware: String)
+    case newChannelMessage(MeshMessage)
+    case newDirectMessage(MeshMessage)
+    case messageAck(messageId: String)
+    /// Werbung eines anderen Nodes mit optionaler Position (ADVERT 0x80, PATH_UPDATED 0x81).
+    case nodeAdvert(contactId: String, name: String?, lat: Double?, lon: Double?)
+    /// Ein Kontakt aus der GET_CONTACTS-Antwort-Sequenz (CONTACT 0x03).
+    case contact(MeshContact)
+    /// Startsignal der GET_CONTACTS-Antwort (CONTACTS_START 0x02).
+    case contactsStart
+    /// Endsignal der GET_CONTACTS-Antwort (END_OF_CONTACTS 0x04).
+    case contactsEnd
+}
+```
+
+Also add `encodeGetContacts` to `MeshCoreProtocol.Command` — it's already there as `getContacts = 0x04`. The function goes in `MeshCoreProtocolService`.
+
+Also add a response alias for SELF_INFO in the existing `Response` enum (after the existing `selfInfo` case):
+
+```swift
+// Already exists:  case selfInfo = 0x05
+```
+
+Check: `Response.selfInfo` already exists (`0x05`). ✓
+
+- [ ] **Step 4: Update MeshCoreProtocolService.swift**
+
+Replace the entire file content with:
+
+```swift
+// MeshCoreMac/Services/MeshCoreProtocolService.swift
+//
+// Encode/Decode für das MeshCore Companion-BLE-Protokoll.
+// Quelle: https://docs.meshcore.io/companion_protocol/
+//
+// Frame-Formate:
+//   SELF_INFO/ADVERT payload: [pubkey:32][ts:4][lat_f32_le:4][lon_f32_le:4][alt_f32_le:4][name:variable]
+//   CONTACT payload:          [pubkey:32][last_heard:4][flags:1][name:variable]
+// VERIFY: Bei neuer Firmware-Version gegen reale Frames abgleichen.
+
+import Foundation
+
+enum MeshCoreProtocolService {
+
+    // MARK: - Encoder
+
+    static func encodeAppStart() -> Data {
+        Data([MeshCoreProtocol.Command.appStart.rawValue])
+    }
+
+    static func encodeDeviceQuery() -> Data {
+        Data([MeshCoreProtocol.Command.deviceQuery.rawValue])
+    }
+
+    static func encodeGetContacts() -> Data {
+        Data([MeshCoreProtocol.Command.getContacts.rawValue])
+    }
+
+    static func encodeSendTextMessage(
+        text: String,
+        channelIndex: UInt8,
+        recipientId: String?
+    ) throws -> Data {
+        guard let textData = text.data(using: .utf8) else {
+            throw ProtocolError.invalidPayload("Text nicht als UTF-8 kodierbar")
+        }
+        guard textData.count <= MeshCoreProtocol.maxMessageLength else {
+            throw ProtocolError.messageTooLong(textData.count)
+        }
+        var frame = Data([MeshCoreProtocol.Command.sendTxtMsg.rawValue, channelIndex])
+        frame.append(textData)
+        return frame
+    }
+
+    // MARK: - Decoder
+
+    static func decodeFrame(_ data: Data) throws -> DecodedFrame {
+        guard !data.isEmpty else { throw ProtocolError.emptyFrame }
+
+        let commandByte = data[data.startIndex]
+        let payload = data.dropFirst()
+
+        if let response = MeshCoreProtocol.Response(rawValue: commandByte) {
+            switch response {
+            case .selfInfo, .deviceInfo:
+                return try decodeNodeInfo(payload)
+            case .channelMsgRecv:
+                return try decodeChannelMessage(payload)
+            case .contactMsgRecv:
+                return try decodeContactMessage(payload)
+            case .sent:
+                return try decodeMsgAck(payload)
+            case .contactsStart:
+                return .contactsStart
+            case .contact:
+                return try decodeContact(payload)
+            case .endOfContacts:
+                return .contactsEnd
+            case .ok, .err, .currTime, .noMoreMessages, .battAndStorage:
+                throw ProtocolError.unknownCommand(commandByte)
+            }
+        }
+
+        if let push = MeshCoreProtocol.Push(rawValue: commandByte) {
+            switch push {
+            case .sendConfirmed:
+                return try decodeMsgAck(payload)
+            case .advert, .pathUpdated:
+                return try decodeAdvertOrSelfInfo(payload)
+            case .msgWaiting, .rawData, .loginSuccess, .loginFail, .statusResponse:
+                throw ProtocolError.unknownCommand(commandByte)
+            }
+        }
+
+        throw ProtocolError.unknownCommand(commandByte)
+    }
+
+    // MARK: - Private Decode Helpers
+
+    /// Dekodiert SELF_INFO (0x05) und DEVICE_INFO (0x0D) Responses.
+    /// Format: [pubkey:32][ts:4][lat_f32_le:4][lon_f32_le:4][alt_f32_le:4][name:variable]
+    private static func decodeNodeInfo(_ payload: Data) throws -> DecodedFrame {
+        let bytes = Array(payload)
+        guard bytes.count >= 4 else {
+            throw ProtocolError.invalidPayload("NODE_INFO payload zu kurz")
+        }
+        let nodeId = bytes.prefix(4).map { String(format: "%02x", $0) }.joined()
+        if bytes.count >= 48 {
+            let lat = readFloat32LE(bytes, offset: 36).map(Double.init)
+            let lon = readFloat32LE(bytes, offset: 40).map(Double.init)
+            let hasPosition = lat != 0.0 || lon != 0.0
+            let rawName = Data(bytes.dropFirst(48))
+            let nameEnd = rawName.firstIndex(of: 0) ?? rawName.endIndex
+            let firmware = String(data: rawName[rawName.startIndex..<nameEnd], encoding: .utf8) ?? "unbekannt"
+            return .selfInfo(
+                nodeId: nodeId,
+                lat: hasPosition ? lat : nil,
+                lon: hasPosition ? lon : nil,
+                firmware: firmware
+            )
+        }
+        // Fallback für kurze Frames ohne Positions-Payload
+        let firmware = String(data: Data(bytes.dropFirst(4)), encoding: .utf8) ?? "unbekannt"
+        return .selfInfo(nodeId: nodeId, lat: nil, lon: nil, firmware: firmware)
+    }
+
+    /// Dekodiert ADVERT (0x80) und PATH_UPDATED (0x81) Push-Notifications.
+    /// Format: [pubkey:32][ts:4][lat_f32_le:4][lon_f32_le:4][alt_f32_le:4][name:variable]
+    private static func decodeAdvertOrSelfInfo(_ payload: Data) throws -> DecodedFrame {
+        let bytes = Array(payload)
+        guard bytes.count >= 4 else {
+            throw ProtocolError.invalidPayload("ADVERT payload zu kurz")
+        }
+        let contactId = bytes.prefix(4).map { String(format: "%02x", $0) }.joined()
+        if bytes.count >= 48 {
+            let lat = readFloat32LE(bytes, offset: 36).map(Double.init)
+            let lon = readFloat32LE(bytes, offset: 40).map(Double.init)
+            let hasPosition = lat != 0.0 || lon != 0.0
+            let rawName = Data(bytes.dropFirst(48))
+            let nameEnd = rawName.firstIndex(of: 0) ?? rawName.endIndex
+            let name = String(data: rawName[rawName.startIndex..<nameEnd], encoding: .utf8)
+            return .nodeAdvert(
+                contactId: contactId,
+                name: name?.isEmpty == false ? name : nil,
+                lat: hasPosition ? lat : nil,
+                lon: hasPosition ? lon : nil
+            )
+        }
+        return .nodeAdvert(contactId: contactId, name: nil, lat: nil, lon: nil)
+    }
+
+    /// Dekodiert einen einzelnen CONTACT (0x03) aus der GET_CONTACTS-Sequenz.
+    /// Format: [pubkey:32][last_heard:4][flags:1][name:variable]
+    private static func decodeContact(_ payload: Data) throws -> DecodedFrame {
+        let bytes = Array(payload)
+        guard bytes.count >= 37 else {
+            throw ProtocolError.invalidPayload("CONTACT payload zu kurz")
+        }
+        let contactId = bytes.prefix(4).map { String(format: "%02x", $0) }.joined()
+        let lastHeardSecs = UInt32(bytes[32]) | UInt32(bytes[33]) << 8 |
+                            UInt32(bytes[34]) << 16 | UInt32(bytes[35]) << 24
+        let lastSeen: Date? = lastHeardSecs > 0
+            ? Date(timeIntervalSince1970: TimeInterval(lastHeardSecs)) : nil
+        let flags = bytes[36]
+        let isOnline = (flags & 0x01) != 0
+        let nameData = Data(bytes.dropFirst(37))
+        let name = String(data: nameData, encoding: .utf8)?.trimmingCharacters(in: .controlCharacters)
+        return .contact(MeshContact(
+            id: contactId,
+            name: name?.isEmpty == false ? name! : contactId,
+            lastSeen: lastSeen,
+            isOnline: isOnline,
+            lat: nil,
+            lon: nil
+        ))
+    }
+
+    private static func decodeChannelMessage(_ payload: Data) throws -> DecodedFrame {
+        guard payload.count >= 3 else {
+            throw ProtocolError.invalidPayload("CHANNEL_MSG payload zu kurz")
+        }
+        let bytes = Array(payload)
+        let channelIndex = Int(bytes[0])
+        let hops = Int(bytes[1])
+        let snrRaw = Int8(bitPattern: bytes[2])
+        let textData = Data(bytes.dropFirst(3))
+        guard let text = String(data: textData, encoding: .utf8) else {
+            throw ProtocolError.invalidPayload("Nachrichtentext kein gültiges UTF-8")
+        }
+        let msg = MeshMessage(
+            id: UUID(),
+            kind: .channel(index: channelIndex),
+            senderName: "Unbekannt",
+            text: text,
+            timestamp: Date(),
+            routing: MeshMessage.Routing(hops: hops, snr: Float(snrRaw), routeDisplay: nil),
+            deliveryStatus: .delivered,
+            isIncoming: true
+        )
+        return .newChannelMessage(msg)
+    }
+
+    private static func decodeContactMessage(_ payload: Data) throws -> DecodedFrame {
+        guard payload.count >= 6 else {
+            throw ProtocolError.invalidPayload("CONTACT_MSG payload zu kurz")
+        }
+        let bytes = Array(payload)
+        let contactId = bytes.prefix(4).map { String(format: "%02x", $0) }.joined()
+        let hops = Int(bytes[4])
+        let snrRaw = Int8(bitPattern: bytes[5])
+        let textData = Data(bytes.dropFirst(6))
+        guard let text = String(data: textData, encoding: .utf8) else {
+            throw ProtocolError.invalidPayload("DM-Text kein gültiges UTF-8")
+        }
+        let msg = MeshMessage(
+            id: UUID(),
+            kind: .direct(contactId: contactId),
+            senderName: contactId,
+            text: text,
+            timestamp: Date(),
+            routing: MeshMessage.Routing(hops: hops, snr: Float(snrRaw), routeDisplay: nil),
+            deliveryStatus: .delivered,
+            isIncoming: true
+        )
+        return .newDirectMessage(msg)
+    }
+
+    private static func decodeMsgAck(_ payload: Data) throws -> DecodedFrame {
+        let msgId = payload.map { String(format: "%02x", $0) }.joined()
+        return .messageAck(messageId: msgId)
+    }
+
+    // MARK: - Byte Helpers
+
+    /// Liest Float32 little-endian aus einem Byte-Array ab `offset`.
+    private static func readFloat32LE(_ bytes: [UInt8], offset: Int) -> Float? {
+        guard offset + 3 < bytes.count else { return nil }
+        let bits = UInt32(bytes[offset])
+            | UInt32(bytes[offset + 1]) << 8
+            | UInt32(bytes[offset + 2]) << 16
+            | UInt32(bytes[offset + 3]) << 24
+        return Float(bitPattern: bits)
+    }
+}
+```
+
+- [ ] **Step 5: Update ChatViewModel.handleFrame switch**
+
+In `MeshCoreMac/ViewModels/ChatViewModel.swift`, replace the `handleFrame` method's switch cases for old `deviceInfo` and `nodeStatus` with the new case names:
+
+```swift
+    private func handleFrame(_ data: Data) async {
+        do {
+            let decoded = try MeshCoreProtocolService.decodeFrame(data)
+            switch decoded {
+            case .newChannelMessage(let msg):
+                guard case .channel(let idx) = msg.kind,
+                      case .channel(let ours) = conversation,
+                      idx == ours else { return }
+                messages.append(msg)
+                try await messageStore.save(msg)
+                if msg.isIncoming {
+                    notificationService.sendNewMessageNotification(
+                        senderName: msg.senderName,
+                        preview: String(msg.text.prefix(60))
+                    )
+                }
+
+            case .newDirectMessage(let msg):
+                guard case .direct(let cid) = msg.kind,
+                      case .direct(let ours) = conversation,
+                      cid == ours else { return }
+                messages.append(msg)
+                try await messageStore.save(msg)
+                if msg.isIncoming {
+                    notificationService.sendNewMessageNotification(
+                        senderName: msg.senderName,
+                        preview: String(msg.text.prefix(60))
+                    )
+                }
+
+            case .messageAck(let msgId):
+                if let idx = messages.firstIndex(where: { $0.id.uuidString == msgId }) {
+                    messages[idx].deliveryStatus = .delivered
+                    try await messageStore.updateDeliveryStatus(
+                        messageId: messages[idx].id, status: .delivered
+                    )
+                }
+
+            case .selfInfo, .nodeAdvert, .contact, .contactsStart, .contactsEnd:
+                break
+            }
+        } catch {
+            #if DEBUG
+            print("[ChatViewModel] Frame decode error: \(error)")
+            #endif
+        }
+    }
+```
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+xcodebuild test -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' 2>&1 | tail -30
+```
+
+Expected: all previous tests still pass, new protocol tests pass. Total count increases.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add MeshCoreMac/Services/MeshCoreProtocol.swift \
+        MeshCoreMac/Services/MeshCoreProtocolService.swift \
+        MeshCoreMac/ViewModels/ChatViewModel.swift \
+        MeshCoreMacTests/Services/MeshCoreProtocolServiceTests.swift
+git commit -m "feat: extend DecodedFrame with position/contact cases, decode ADVERT/SELF_INFO/CONTACT frames"
+```
+
+---
+
+## Task 3: BluetoothService — nodeEventStream + GET_CONTACTS
+
+BluetoothService gets a second typed stream for contact/node events. ChatViewModel's existing `incomingFrames: AsyncStream<Data>` is untouched. BluetoothService decodes each incoming BLE frame twice: raw bytes go to `incomingFrames`, decoded node events go to `nodeEventStream`. GET_CONTACTS is added to the init sequence.
+
+**Files:**
+- Modify: `MeshCoreMac/Services/BluetoothServiceProtocol.swift`
+- Modify: `MeshCoreMac/Services/MeshCoreBluetoothService.swift`
+- Modify: `MeshCoreMacTests/Services/MockBluetoothService.swift`
+
+- [ ] **Step 1: Update BluetoothServiceProtocol**
+
+Replace `MeshCoreMac/Services/BluetoothServiceProtocol.swift` with:
+
+```swift
+// MeshCoreMac/Services/BluetoothServiceProtocol.swift
+import CoreBluetooth
+import Foundation
+
+@MainActor
+protocol BluetoothServiceProtocol: AnyObject {
+    var connectionState: ConnectionState { get }
+    var discoveredDevices: [CBPeripheral] { get }
+    /// Rohe BLE-Frames (Node → App). ChatViewModel konsumiert diesen Stream.
+    var incomingFrames: AsyncStream<Data> { get }
+    /// Dekodierte Node-Ereignisse: selfInfo, nodeAdvert, contact, contactsStart/End.
+    var nodeEventStream: AsyncStream<DecodedFrame> { get }
+
+    func startScanning()
+    func stopScanning()
+    func connect(to peripheral: CBPeripheral)
+    func disconnect()
+    func send(_ data: Data) throws
+    func setLastKnownPeripheralId(_ id: UUID?)
+}
+```
+
+- [ ] **Step 2: Update MockBluetoothService**
+
+Replace `MeshCoreMacTests/Services/MockBluetoothService.swift` with:
+
+```swift
+// MeshCoreMacTests/Services/MockBluetoothService.swift
+import CoreBluetooth
+import Foundation
+@testable import MeshCoreMac
+
+@Observable
+@MainActor
+final class MockBluetoothService: BluetoothServiceProtocol {
+    var connectionState: ConnectionState = .disconnected
+    var discoveredDevices: [CBPeripheral] = []
+    let incomingFrames: AsyncStream<Data>
+    private let frameContinuation: AsyncStream<Data>.Continuation
+    let nodeEventStream: AsyncStream<DecodedFrame>
+    private let nodeEventContinuation: AsyncStream<DecodedFrame>.Continuation
+
+    var sentFrames: [Data] = []
+    var scanStarted = false
+    var disconnectCalled = false
+
+    init() {
+        let (stream, continuation) = AsyncStream<Data>.makeStream()
+        self.incomingFrames = stream
+        self.frameContinuation = continuation
+        let (nodeStream, nodeCont) = AsyncStream<DecodedFrame>.makeStream()
+        self.nodeEventStream = nodeStream
+        self.nodeEventContinuation = nodeCont
+    }
+
+    func startScanning() { scanStarted = true }
+    func stopScanning() { scanStarted = false }
+
+    func connect(to peripheral: CBPeripheral) {
+        connectionState = .ready(peripheralName: peripheral.name ?? "Mock-Node")
+    }
+
+    func disconnect() {
+        disconnectCalled = true
+        connectionState = .disconnected
+    }
+
+    func send(_ data: Data) throws { sentFrames.append(data) }
+    func setLastKnownPeripheralId(_ id: UUID?) {}
+
+    // MARK: - Test-Helpers
+
+    func simulateIncomingFrame(_ data: Data) {
+        frameContinuation.yield(data)
+    }
+
+    func simulateNodeEvent(_ frame: DecodedFrame) {
+        nodeEventContinuation.yield(frame)
+    }
+
+    func simulateDisconnect() {
+        connectionState = .failed(peripheralName: "Mock-Node", error: "Verbindung verloren")
+    }
+
+    func simulateConnect(peripheralName: String = "Mock-Node") {
+        connectionState = .ready(peripheralName: peripheralName)
+    }
+}
+```
+
+- [ ] **Step 3: Update MeshCoreBluetoothService**
+
+In `MeshCoreMac/Services/MeshCoreBluetoothService.swift`, make these changes:
+
+**3a.** Add `nodeEventStream` and `nodeEventContinuation` properties after `frameContinuation`:
+
+```swift
+    // MARK: - Async Frame Stream
+    let incomingFrames: AsyncStream<Data>
+    private let frameContinuation: AsyncStream<Data>.Continuation
+    let nodeEventStream: AsyncStream<DecodedFrame>
+    private let nodeEventContinuation: AsyncStream<DecodedFrame>.Continuation
+```
+
+**3b.** Update `init()` to initialise both streams:
+
+```swift
+    override init() {
+        let (stream, continuation) = AsyncStream<Data>.makeStream()
+        self.incomingFrames = stream
+        self.frameContinuation = continuation
+        let (nodeStream, nodeCont) = AsyncStream<DecodedFrame>.makeStream()
+        self.nodeEventStream = nodeStream
+        self.nodeEventContinuation = nodeCont
+        super.init()
+        self.centralManager = CBCentralManager(delegate: self, queue: .main)
+    }
+```
+
+**3c.** Update `deinit` to finish both continuations:
+
+```swift
+    deinit {
+        frameContinuation.finish()
+        nodeEventContinuation.finish()
+    }
+```
+
+**3d.** Update `didUpdateValueFor` in the `CBPeripheralDelegate` extension to route node events:
+
+```swift
+    func peripheral(
+        _ peripheral: CBPeripheral,
+        didUpdateValueFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        guard error == nil, let value = characteristic.value else { return }
+        frameContinuation.yield(value)
+
+        // Route decoded node events to nodeEventStream (ChatViewModel ignores these via break)
+        if let decoded = try? MeshCoreProtocolService.decodeFrame(value) {
+            switch decoded {
+            case .selfInfo, .nodeAdvert, .contact, .contactsStart, .contactsEnd:
+                nodeEventContinuation.yield(decoded)
+            case .newChannelMessage, .newDirectMessage, .messageAck:
+                break
+            }
+        }
+    }
+```
+
+**3e.** Update `sendInitSequence` to also request contacts:
+
+```swift
+    private func sendInitSequence() {
+        try? send(MeshCoreProtocolService.encodeAppStart())
+        try? send(MeshCoreProtocolService.encodeDeviceQuery())
+        try? send(MeshCoreProtocolService.encodeGetContacts())
+    }
+```
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+xcodebuild test -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' 2>&1 | tail -20
+```
+
+Expected: all tests pass. The new `nodeEventStream` property is present but not yet consumed by any ViewModel — that's fine.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add MeshCoreMac/Services/BluetoothServiceProtocol.swift \
+        MeshCoreMac/Services/MeshCoreBluetoothService.swift \
+        MeshCoreMacTests/Services/MockBluetoothService.swift
+git commit -m "feat: add nodeEventStream to BluetoothService, send GET_CONTACTS on connect"
+```
+
+---
+
+## Task 4: ContactsViewModel
+
+ContactsViewModel subscribes to `nodeEventStream`, persists contacts to ContactStore, and maintains an in-memory list for the UI. It also tracks own-node position from `selfInfo` events.
+
+**Files:**
+- Create: `MeshCoreMac/ViewModels/ContactsViewModel.swift`
+- Create: `MeshCoreMacTests/ViewModels/ContactsViewModelTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `MeshCoreMacTests/ViewModels/ContactsViewModelTests.swift`:
+
+```swift
+import XCTest
+import CoreLocation
+@testable import MeshCoreMac
+
+@MainActor
+final class ContactsViewModelTests: XCTestCase {
+
+    var mockBluetooth: MockBluetoothService!
+    var contactStore: ContactStore!
+    var vm: ContactsViewModel!
+
+    override func setUp() async throws {
+        mockBluetooth = MockBluetoothService()
+        contactStore = try ContactStore(inMemory: true)
+        vm = ContactsViewModel(contactStore: contactStore, bluetoothService: mockBluetooth)
+        await vm.start()
+    }
+
+    func testNodeAdvert_addsContactToList() async throws {
+        mockBluetooth.simulateNodeEvent(
+            .nodeAdvert(contactId: "a1b2c3d4", name: "Alice", lat: 48.137, lon: 11.575)
+        )
+        try await waitUntil { !self.vm.contacts.isEmpty }
+        XCTAssertEqual(vm.contacts.count, 1)
+        XCTAssertEqual(vm.contacts[0].name, "Alice")
+        XCTAssertTrue(vm.contacts[0].isOnline)
+        XCTAssertEqual(vm.contacts[0].lat ?? 0, 48.137, accuracy: 0.001)
+    }
+
+    func testNodeAdvert_persistsToStore() async throws {
+        mockBluetooth.simulateNodeEvent(
+            .nodeAdvert(contactId: "a1b2c3d4", name: "Alice", lat: nil, lon: nil)
+        )
+        try await waitUntil { !self.vm.contacts.isEmpty }
+        let stored = try await contactStore.fetchAll()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored[0].name, "Alice")
+    }
+
+    func testContactEvent_addsToList() async throws {
+        let contact = MeshContact(id: "dead1234", name: "Bob",
+                                   lastSeen: nil, isOnline: true,
+                                   lat: nil, lon: nil)
+        mockBluetooth.simulateNodeEvent(.contact(contact))
+        try await waitUntil { !self.vm.contacts.isEmpty }
+        XCTAssertEqual(vm.contacts[0].name, "Bob")
+    }
+
+    func testSelfInfo_setsOwnPosition() async throws {
+        mockBluetooth.simulateNodeEvent(
+            .selfInfo(nodeId: "aa11bb22", lat: 52.52, lon: 13.405, firmware: "v1.0")
+        )
+        try await waitUntil { self.vm.ownPosition != nil }
+        XCTAssertEqual(vm.ownPosition?.latitude ?? 0, 52.52, accuracy: 0.001)
+        XCTAssertEqual(vm.ownPosition?.longitude ?? 0, 13.405, accuracy: 0.001)
+    }
+
+    func testStart_loadsPersistedContacts() async throws {
+        let contact = MeshContact(id: "cafe1234", name: "Charlie",
+                                   lastSeen: nil, isOnline: false,
+                                   lat: nil, lon: nil)
+        try await contactStore.save(contact)
+
+        let newVM = ContactsViewModel(contactStore: contactStore, bluetoothService: mockBluetooth)
+        await newVM.start()
+
+        XCTAssertEqual(newVM.contacts.count, 1)
+        XCTAssertEqual(newVM.contacts[0].name, "Charlie")
+    }
+
+    func testUpdateContact_persistsNameChange() async throws {
+        var contact = MeshContact(id: "aa11bb22", name: "Dave",
+                                   lastSeen: nil, isOnline: false,
+                                   lat: nil, lon: nil)
+        mockBluetooth.simulateNodeEvent(.contact(contact))
+        try await waitUntil { !self.vm.contacts.isEmpty }
+
+        contact.name = "Dave Updated"
+        await vm.updateContact(contact)
+
+        let stored = try await contactStore.fetchAll()
+        XCTAssertEqual(stored.first?.name, "Dave Updated")
+        XCTAssertEqual(vm.contacts.first?.name, "Dave Updated")
+    }
+
+    // MARK: - Helper
+
+    private func waitUntil(
+        timeout: TimeInterval = 1.0,
+        condition: @escaping () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            guard Date() < deadline else {
+                XCTFail("Timeout waiting for condition")
+                return
+            }
+            await Task.yield()
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+xcodebuild test -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' \
+  -only-testing:MeshCoreMacTests/ContactsViewModelTests 2>&1 | tail -20
+```
+
+Expected: compile error — `ContactsViewModel` not found.
+
+- [ ] **Step 3: Create ContactsViewModel**
+
+Create `MeshCoreMac/ViewModels/ContactsViewModel.swift`:
+
+```swift
+// MeshCoreMac/ViewModels/ContactsViewModel.swift
+import CoreLocation
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ContactsViewModel {
+    private(set) var contacts: [MeshContact] = []
+    private(set) var ownPosition: CLLocationCoordinate2D? = nil
+
+    private let contactStore: ContactStore
+    private let bluetoothService: any BluetoothServiceProtocol
+
+    nonisolated(unsafe) private var listenerTask: Task<Void, Never>?
+
+    init(contactStore: ContactStore, bluetoothService: any BluetoothServiceProtocol) {
+        self.contactStore = contactStore
+        self.bluetoothService = bluetoothService
+    }
+
+    func start() async {
+        contacts = (try? await contactStore.fetchAll()) ?? []
+        startListening()
+    }
+
+    func updateContact(_ contact: MeshContact) async {
+        try? await contactStore.save(contact)
+        upsert(contact)
+    }
+
+    private func startListening() {
+        listenerTask?.cancel()
+        listenerTask = Task {
+            for await event in self.bluetoothService.nodeEventStream {
+                guard !Task.isCancelled else { break }
+                await self.handleNodeEvent(event)
+            }
+        }
+    }
+
+    private func handleNodeEvent(_ frame: DecodedFrame) async {
+        switch frame {
+        case .selfInfo(_, let lat, let lon, _):
+            if let lat = lat, let lon = lon {
+                ownPosition = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+            }
+        case .nodeAdvert(let contactId, let name, let lat, let lon):
+            var c = contacts.first(where: { $0.id == contactId })
+                ?? MeshContact(id: contactId, name: name ?? contactId,
+                               lastSeen: nil, isOnline: false, lat: nil, lon: nil)
+            c.isOnline = true
+            c.lastSeen = Date()
+            if let name = name { c.name = name }
+            if let lat = lat { c.lat = lat }
+            if let lon = lon { c.lon = lon }
+            try? await contactStore.save(c)
+            upsert(c)
+        case .contact(let c):
+            try? await contactStore.save(c)
+            upsert(c)
+        case .contactsStart, .contactsEnd:
+            break
+        case .newChannelMessage, .newDirectMessage, .messageAck:
+            break
+        }
+    }
+
+    private func upsert(_ contact: MeshContact) {
+        if let idx = contacts.firstIndex(where: { $0.id == contact.id }) {
+            contacts[idx] = contact
+        } else {
+            contacts.append(contact)
+        }
+    }
+
+    deinit { listenerTask?.cancel() }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+xcodebuild test -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' \
+  -only-testing:MeshCoreMacTests/ContactsViewModelTests 2>&1 | tail -20
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+xcodebuild test -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add MeshCoreMac/ViewModels/ContactsViewModel.swift \
+        MeshCoreMacTests/ViewModels/ContactsViewModelTests.swift
+git commit -m "feat: add ContactsViewModel — subscribes to nodeEventStream, persists contacts"
+```
+
+---
+
+## Task 5: AppContainer + SidebarViewModel Wiring
+
+Wire ContactStore and ContactsViewModel into AppContainer. SidebarViewModel drops its `contacts` and `updateContact` (owned by ContactsViewModel). SidebarView gets a `contactsVM` parameter.
+
+**Files:**
+- Modify: `MeshCoreMac/App/AppContainer.swift`
+- Modify: `MeshCoreMac/ViewModels/SidebarViewModel.swift`
+- Modify: `MeshCoreMac/App/MeshCoreMacApp.swift` (to call `contactsViewModel.start()` on app launch)
+
+There are no new tests for this task — the integration is covered by the existing ViewModel tests. Run the full suite to confirm nothing is broken.
+
+- [ ] **Step 1: Update SidebarViewModel**
+
+Replace `MeshCoreMac/ViewModels/SidebarViewModel.swift` with:
+
+```swift
+// MeshCoreMac/ViewModels/SidebarViewModel.swift
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class SidebarViewModel {
+    var channels: [MeshChannel] = []
+    var selectedConversation: MeshMessage.Kind? = nil
+
+    init() {
+        loadDefaultChannels()
+    }
+
+    private func loadDefaultChannels() {
+        channels = [MeshChannel(id: 0, name: "Allgemein")]
+    }
+
+    func addChannel(_ channel: MeshChannel) {
+        if !channels.contains(channel) {
+            channels.append(channel)
+        }
+    }
+
+    func selectConversation(_ kind: MeshMessage.Kind) {
+        selectedConversation = kind
+    }
+}
+```
+
+- [ ] **Step 2: Update AppContainer**
+
+Replace `MeshCoreMac/App/AppContainer.swift` with:
+
+```swift
+// MeshCoreMac/App/AppContainer.swift
+import Foundation
+
+@MainActor
+final class AppContainer {
+    let bluetoothService: MeshCoreBluetoothService
+    let messageStore: MessageStore
+    let contactStore: ContactStore
+    let connectionViewModel: ConnectionViewModel
+    let sidebarViewModel: SidebarViewModel
+    let contactsViewModel: ContactsViewModel
+    let notificationService: NotificationService
+
+    init() throws {
+        bluetoothService = MeshCoreBluetoothService()
+        messageStore = try MessageStore()
+        contactStore = try ContactStore()
+        connectionViewModel = ConnectionViewModel(bluetoothService: bluetoothService)
+        sidebarViewModel = SidebarViewModel()
+        notificationService = NotificationService()
+        contactsViewModel = ContactsViewModel(
+            contactStore: contactStore,
+            bluetoothService: bluetoothService
+        )
+    }
+
+    func makeChatViewModel(for conversation: MeshMessage.Kind) -> ChatViewModel {
+        ChatViewModel(
+            bluetoothService: bluetoothService,
+            messageStore: messageStore,
+            conversation: conversation,
+            notificationService: notificationService
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Start ContactsViewModel on app launch**
+
+In `MeshCoreMac/App/MeshCoreMacApp.swift`, find the `WindowGroup { MainWindowView(container: container) }` scene and add a `.task` modifier to start ContactsViewModel:
+
+The existing file looks like:
+```swift
+WindowGroup {
+    MainWindowView(container: container)
+}
+```
+
+Change it to:
+```swift
+WindowGroup {
+    MainWindowView(container: container)
+        .task { await container.contactsViewModel.start() }
+}
+```
+
+Read the full file first to find the exact location, then make this targeted edit.
+
+- [ ] **Step 4: Run full test suite to confirm nothing broken**
+
+```bash
+xcodebuild test -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' 2>&1 | tail -20
+```
+
+Expected: all tests pass (SidebarViewModel tests don't exist for contacts since that was Phase 1 dead code, so nothing breaks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add MeshCoreMac/ViewModels/SidebarViewModel.swift \
+        MeshCoreMac/App/AppContainer.swift \
+        MeshCoreMac/App/MeshCoreMacApp.swift
+git commit -m "feat: wire ContactStore + ContactsViewModel into AppContainer, start on launch"
+```
+
+---
+
+## Task 6: ContactDetailView + SidebarView Navigation
+
+A sheet for viewing and editing a contact. The SidebarView shows the contact list from ContactsViewModel and opens the sheet on click.
+
+**Files:**
+- Create: `MeshCoreMac/Views/MainWindow/ContactDetailView.swift`
+- Modify: `MeshCoreMac/Views/MainWindow/SidebarView.swift`
+
+No new tests — UI-only components. Verify by building with `xcodebuild build`.
+
+- [ ] **Step 1: Create ContactDetailView**
+
+Create `MeshCoreMac/Views/MainWindow/ContactDetailView.swift`:
+
+```swift
+// MeshCoreMac/Views/MainWindow/ContactDetailView.swift
+import SwiftUI
+
+struct ContactDetailView: View {
+    @State var contact: MeshContact
+    let onSave: (MeshContact) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        Form {
+            Section("Identität") {
+                LabeledContent("Node-ID", value: contact.id)
+                LabeledContent("Name") {
+                    TextField("Name", text: $contact.name)
+                        .multilineTextAlignment(.trailing)
+                }
+            }
+            Section("Status") {
+                LabeledContent("Online") {
+                    HStack {
+                        Circle()
+                            .fill(contact.isOnline ? Color.green : Color.red)
+                            .frame(width: 10, height: 10)
+                        Text(contact.isOnline ? "Ja" : "Nein")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if let lastSeen = contact.lastSeen {
+                    LabeledContent("Zuletzt gesehen",
+                                   value: lastSeen.formatted(date: .abbreviated, time: .shortened))
+                }
+            }
+            if contact.lat != nil || contact.lon != nil {
+                Section("Position") {
+                    if let lat = contact.lat {
+                        LabeledContent("Breite", value: String(format: "%.6f°", lat))
+                    }
+                    if let lon = contact.lon {
+                        LabeledContent("Länge", value: String(format: "%.6f°", lon))
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle(contact.name)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Abbrechen") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Sichern") {
+                    onSave(contact)
+                    dismiss()
+                }
+            }
+        }
+        .frame(minWidth: 320, minHeight: 280)
+    }
+}
+```
+
+- [ ] **Step 2: Update SidebarView**
+
+Replace `MeshCoreMac/Views/MainWindow/SidebarView.swift` with:
+
+```swift
+// MeshCoreMac/Views/MainWindow/SidebarView.swift
+import SwiftUI
+
+struct SidebarView: View {
+    let sidebarVM: SidebarViewModel
+    let connectionVM: ConnectionViewModel
+    let contactsVM: ContactsViewModel
+
+    @State private var selectedContactForDetail: MeshContact? = nil
+
+    var body: some View {
+        List(selection: Binding(
+            get: { sidebarVM.selectedConversation.map(ConversationID.init) },
+            set: { id in
+                if let kind = id?.kind { sidebarVM.selectConversation(kind) }
+            }
+        )) {
+            Section("Kanäle") {
+                ForEach(sidebarVM.channels) { channel in
+                    Label("# \(channel.name)", systemImage: "number")
+                        .tag(ConversationID(kind: .channel(index: channel.id)))
+                }
+            }
+
+            if !contactsVM.contacts.isEmpty {
+                Section("Direkt") {
+                    ForEach(contactsVM.contacts) { contact in
+                        HStack {
+                            Label(contact.name, systemImage: "person.fill")
+                                .tag(ConversationID(kind: .direct(contactId: contact.id)))
+                            Spacer()
+                            Circle()
+                                .fill(contact.isOnline ? Color.green : Color.red)
+                                .frame(width: 8, height: 8)
+                            Button {
+                                selectedContactForDetail = contact
+                            } label: {
+                                Image(systemName: "info.circle")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .safeAreaInset(edge: .bottom) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(connectionVM.connectionState.isConnectedOrReady ? Color.green : Color.red)
+                    .frame(width: 8, height: 8)
+                Text(connectionVM.connectionState.displayName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+        }
+        .sheet(item: $selectedContactForDetail) { contact in
+            NavigationStack {
+                ContactDetailView(contact: contact) { updated in
+                    Task { await contactsVM.updateContact(updated) }
+                }
+            }
+        }
+    }
+}
+
+struct ConversationID: Hashable {
+    let kind: MeshMessage.Kind
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+xcodebuild build -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' 2>&1 | grep -E "error:|BUILD"
+```
+
+Expected: `BUILD SUCCEEDED` with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add MeshCoreMac/Views/MainWindow/ContactDetailView.swift \
+        MeshCoreMac/Views/MainWindow/SidebarView.swift
+git commit -m "feat: add ContactDetailView, SidebarView shows contacts from ContactsViewModel"
+```
+
+---
+
+## Task 7: MapView
+
+A SwiftUI `Map` showing all known nodes as pins. Uses `MapKit`'s modern SwiftUI API (macOS 14+). Own-node position shown in blue, contacts in green (online) or gray (offline). No MapKit entitlement needed on macOS.
+
+**Files:**
+- Create: `MeshCoreMac/Views/Map/MapView.swift`
+
+No new tests — pure view with no logic.
+
+- [ ] **Step 1: Create MapView**
+
+Create `MeshCoreMac/Views/Map/MapView.swift`:
+
+```swift
+// MeshCoreMac/Views/Map/MapView.swift
+import CoreLocation
+import MapKit
+import SwiftUI
+
+struct NodeMapView: View {
+    let contacts: [MeshContact]
+    let ownPosition: CLLocationCoordinate2D?
+
+    private var nodesWithPosition: [MeshContact] {
+        contacts.filter { $0.lat != nil && $0.lon != nil }
+    }
+
+    var body: some View {
+        Group {
+            if ownPosition == nil && nodesWithPosition.isEmpty {
+                emptyState
+            } else {
+                mapContent
+            }
+        }
+        .navigationTitle("Karte")
+        .frame(minWidth: 500, minHeight: 400)
+    }
+
+    private var mapContent: some View {
+        Map {
+            if let pos = ownPosition {
+                Annotation("Mein Node", coordinate: pos) {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .foregroundStyle(.white)
+                        .padding(6)
+                        .background(Color.blue, in: Circle())
+                }
+            }
+            ForEach(nodesWithPosition) { contact in
+                let coord = CLLocationCoordinate2D(
+                    latitude: contact.lat!,
+                    longitude: contact.lon!
+                )
+                Annotation(contact.name, coordinate: coord) {
+                    Image(systemName: "person.circle.fill")
+                        .foregroundStyle(.white)
+                        .padding(6)
+                        .background(
+                            contact.isOnline ? Color.green : Color.gray,
+                            in: Circle()
+                        )
+                }
+            }
+        }
+        .mapStyle(.standard(elevation: .flat))
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "Keine Positionen",
+            systemImage: "map",
+            description: Text("Warte auf GPS-Daten von Nodes in der Nähe.")
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+xcodebuild build -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' 2>&1 | grep -E "error:|BUILD"
+```
+
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add MeshCoreMac/Views/Map/MapView.swift
+git commit -m "feat: add NodeMapView with SwiftUI Map, shows node positions as pins"
+```
+
+---
+
+## Task 8: UI Integration — ChatView Title + MainWindowView Map Toolbar
+
+Resolve contact names in ChatView DM titles and add a map toolbar button to MainWindowView.
+
+**Files:**
+- Modify: `MeshCoreMac/Views/MainWindow/ChatView.swift`
+- Modify: `MeshCoreMac/Views/MainWindow/MainWindowView.swift`
+
+- [ ] **Step 1: Update ChatView to accept contactsVM and resolve DM title**
+
+Read `MeshCoreMac/Views/MainWindow/ChatView.swift` (do not modify yet). The current `conversationTitle` for `.direct(let cid)` returns the raw `cid`. We need to look up the name from `contactsVM.contacts`.
+
+Replace `MeshCoreMac/Views/MainWindow/ChatView.swift` with:
+
+```swift
+// MeshCoreMac/Views/MainWindow/ChatView.swift
+import SwiftUI
+
+struct ChatView: View {
+    @Bindable var chatVM: ChatViewModel
+    let conversation: MeshMessage.Kind
+    let contactsVM: ContactsViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let error = chatVM.errorMessage {
+                ErrorBannerView(message: error) {
+                    chatVM.errorMessage = nil
+                }
+            }
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 8) {
+                        ForEach(chatVM.messages) { msg in
+                            MessageBubbleView(message: msg)
+                                .id(msg.id)
+                        }
+                    }
+                    .padding(.vertical, 12)
+                }
+                .onChange(of: chatVM.messages.count) { _, _ in
+                    if let last = chatVM.messages.last {
+                        withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
+                    }
+                }
+            }
+
+            Divider()
+
+            HStack(alignment: .bottom, spacing: 8) {
+                VStack(alignment: .trailing, spacing: 2) {
+                    TextField("Nachricht eingeben…", text: $chatVM.inputText, axis: .vertical)
+                        .lineLimit(1...5)
+                        .textFieldStyle(.plain)
+
+                    let count = chatVM.inputText.utf8.count
+                    Text("\(count)/\(MeshCoreProtocol.maxMessageLength)")
+                        .font(.caption2)
+                        .foregroundStyle(count > MeshCoreProtocol.maxMessageLength ? Color.red : Color.secondary)
+                }
+
+                Button {
+                    Task { await trySend() }
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                }
+                .disabled(
+                    chatVM.inputText.trimmingCharacters(in: .whitespaces).isEmpty ||
+                    chatVM.inputText.utf8.count > MeshCoreProtocol.maxMessageLength
+                )
+                .keyboardShortcut(.return, modifiers: .command)
+            }
+            .padding(12)
+            .background(.ultraThinMaterial)
+        }
+        .task { await chatVM.loadMessages() }
+        .navigationTitle(conversationTitle)
+    }
+
+    private var conversationTitle: String {
+        switch conversation {
+        case .channel(let idx):
+            return "Kanal \(idx)"
+        case .direct(let cid):
+            return contactsVM.contacts.first(where: { $0.id == cid })?.name ?? cid
+        }
+    }
+
+    private func trySend() async {
+        do {
+            try await chatVM.send(text: chatVM.inputText)
+        } catch {
+            chatVM.errorMessage = error.localizedDescription
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update MainWindowView**
+
+Replace `MeshCoreMac/Views/MainWindow/MainWindowView.swift` with:
+
+```swift
+// MeshCoreMac/Views/MainWindow/MainWindowView.swift
+import SwiftUI
+
+struct MainWindowView: View {
+    let container: AppContainer
+
+    @State private var dismissedError: String? = nil
+    @State private var showingMap = false
+
+    var body: some View {
+        Group {
+            if container.connectionViewModel.connectionState.isConnectedOrReady {
+                messengerView
+            } else {
+                PairingView(connectionVM: container.connectionViewModel)
+            }
+        }
+        .frame(minWidth: 700, minHeight: 500)
+        .overlay(alignment: .top) {
+            if let err = container.connectionViewModel.errorMessage,
+               err != dismissedError {
+                ErrorBannerView(
+                    message: err,
+                    onDismiss: { dismissedError = err },
+                    onRetry: { container.connectionViewModel.startScan() }
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .animation(.easeInOut, value: err)
+            }
+        }
+        .onChange(of: container.connectionViewModel.errorMessage) { _, newError in
+            if newError != dismissedError {
+                dismissedError = nil
+            }
+        }
+        .sheet(isPresented: $showingMap) {
+            NavigationStack {
+                NodeMapView(
+                    contacts: container.contactsViewModel.contacts,
+                    ownPosition: container.contactsViewModel.ownPosition
+                )
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Schließen") { showingMap = false }
+                    }
+                }
+            }
+        }
+    }
+
+    private var messengerView: some View {
+        NavigationSplitView {
+            SidebarView(
+                sidebarVM: container.sidebarViewModel,
+                connectionVM: container.connectionViewModel,
+                contactsVM: container.contactsViewModel
+            )
+            .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 280)
+        } detail: {
+            if let conversation = container.sidebarViewModel.selectedConversation {
+                ChatView(
+                    chatVM: container.makeChatViewModel(for: conversation),
+                    conversation: conversation,
+                    contactsVM: container.contactsViewModel
+                )
+            } else {
+                ContentUnavailableView(
+                    "Keine Konversation gewählt",
+                    systemImage: "bubble.left.and.bubble.right",
+                    description: Text("Wähle einen Kanal oder Kontakt in der Sidebar.")
+                )
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    showingMap = true
+                } label: {
+                    Label("Karte", systemImage: "map")
+                }
+                .help("Karte aller bekannten Nodes anzeigen")
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+xcodebuild build -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' 2>&1 | grep -E "error:|BUILD"
+```
+
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+xcodebuild test -project MeshCoreMac.xcodeproj -scheme MeshCoreMac \
+  -destination 'platform=macOS' 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add MeshCoreMac/Views/MainWindow/ChatView.swift \
+        MeshCoreMac/Views/MainWindow/MainWindowView.swift
+git commit -m "feat: resolve DM contact names in ChatView, add Map toolbar button"
+```
+
+---
+
+## Self-Review Checklist
+
+### 1. Spec Coverage
+
+| Requirement | Task |
+|---|---|
+| Contacts persistent in SQLite | Task 1, 4 |
+| Contacts populated from BLE ADVERT | Task 2, 3, 4 |
+| Contacts populated from GET_CONTACTS | Task 2, 3, 4 |
+| Own node position from SELF_INFO | Task 2, 3, 4 |
+| Editable contact names | Task 6 |
+| Last seen + online status in detail | Task 6 |
+| Map showing node positions | Task 7 |
+| Map accessible from main window | Task 8 |
+| DM titles show contact name | Task 8 |
+| Existing tests remain green | all tasks |
+
+### 2. Placeholder Scan
+
+No TBD/TODO/placeholder items — all code is complete.
+
+### 3. Type Consistency
+
+- `MeshContact(id:name:lastSeen:isOnline:lat:lon:)` — defined Task 1, used consistently Tasks 2–8
+- `ContactsViewModel.contacts: [MeshContact]` — defined Task 4, read in Tasks 6, 7, 8
+- `BluetoothServiceProtocol.nodeEventStream: AsyncStream<DecodedFrame>` — defined Task 3, consumed Task 4
+- `NodeMapView` (not `MapView`) — defined Task 7, used Task 8 (avoids collision with SwiftUI `MapView` type alias)
+- `DecodedFrame.selfInfo(nodeId:lat:lon:firmware:)` — defined Task 2, handled Tasks 3, 4, ViewModel switch


### PR DESCRIPTION
## Summary

- Kontakte aus MeshCore-Protokoll (ADVERT, GET_CONTACTS, SELF_INFO) werden persistiert und in der Sidebar angezeigt
- `ContactDetailView` ermöglicht das Bearbeiten von Kontaktnamen und zeigt Position, Online-Status und Last-Seen
- `NodeMapView` (SwiftUI MapKit) zeigt alle Nodes mit Position als Pins — eigener Node blau, Kontakte grün/grau
- Karten-Button in der Toolbar öffnet die Karte als Sheet mit Live-Updates

## Architecture

- `ContactStore` (GRDB) — persistiert Kontakte, Pendant zu `MessageStore`
- `ContactsViewModel` — abonniert neuen `nodeEventStream: AsyncStream<DecodedFrame>` auf BluetoothService, flush-and-rebuild für GET_CONTACTS-Sequenz
- `DecodedFrame` erweitert um `.selfInfo`, `.nodeAdvert`, `.contact`, `.contactsStart`, `.contactsEnd`
- `MeshCoreBluetoothService` decoded Frames einmal und routet an `incomingFrames` (ChatViewModel) und `nodeEventStream` (ContactsViewModel)
- `ChatContainer` hält stable `ChatViewModel` per Gesprächs-ID via `@State`, verhindert AsyncStream-Konflikte bei SwiftUI-Re-Renders

## Test Plan

- [x] 46/46 Tests bestanden (inkl. 12 neue Tests für ContactStore, ContactsViewModel, ProtocolService)
- [x] Edge Cases: `contactsEnd` ohne `contactsStart`, `contactsStart` zweifach, `start()` doppelter Aufruf
- [x] Build: `BUILD SUCCEEDED` ohne Fehler
- [ ] Manuelle Verifikation mit echtem MeshCore-Node (BLE-Verbindung, Kontaktliste, Kartenanzeige)

## Commits

15 Commits — Features + Quality-Review-Fixes auf `feature/phase-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)