### PR TITLE
feat(phase3): Netzwerk-Tools — RX Log, CLI, Node Status

### DIFF
--- a/MeshCoreMac/App/AppContainer.swift
+++ b/MeshCoreMac/App/AppContainer.swift
@@ -9,6 +9,7 @@ final class AppContainer {
     let connectionViewModel: ConnectionViewModel
     let sidebarViewModel: SidebarViewModel
     let contactsViewModel: ContactsViewModel
+    let diagnosticsViewModel: DiagnosticsViewModel
     let notificationService: NotificationService
 
     init() throws {
@@ -18,6 +19,7 @@ final class AppContainer {
         connectionViewModel = ConnectionViewModel(bluetoothService: bluetoothService)
         sidebarViewModel = SidebarViewModel()
         contactsViewModel = ContactsViewModel(contactStore: contactStore, bluetoothService: bluetoothService)
+        diagnosticsViewModel = DiagnosticsViewModel(bluetoothService: bluetoothService)
         notificationService = NotificationService()
     }
 

--- a/MeshCoreMac/App/MeshCoreMacApp.swift
+++ b/MeshCoreMac/App/MeshCoreMacApp.swift
@@ -21,6 +21,7 @@ struct MeshCoreMacApp: App {
         WindowGroup {
             MainWindowView(container: container)
                 .task { await container.contactsViewModel.start() }
+                .task { await container.diagnosticsViewModel.start() }
                 .onDisappear {
                     appDelegate.switchToAccessoryMode()
                 }

--- a/MeshCoreMac/Models/RxLogEntry.swift
+++ b/MeshCoreMac/Models/RxLogEntry.swift
@@ -1,0 +1,21 @@
+// MeshCoreMac/Models/RxLogEntry.swift
+import Foundation
+
+struct RxLogEntry: Identifiable, Sendable {
+    enum Direction: String, Sendable {
+        case incoming = "↓"
+        case outgoing = "↑"
+    }
+
+    let id: UUID
+    let timestamp: Date
+    let direction: Direction
+    let rawBytes: Data
+    let decoded: String?
+
+    var hexString: String {
+        rawBytes.map { String(format: "%02X", $0) }.joined(separator: " ")
+    }
+
+    var commandByte: UInt8? { rawBytes.first }
+}

--- a/MeshCoreMac/Services/BluetoothServiceProtocol.swift
+++ b/MeshCoreMac/Services/BluetoothServiceProtocol.swift
@@ -15,6 +15,8 @@ protocol BluetoothServiceProtocol: AnyObject {
     var incomingFrames: AsyncStream<Data> { get }
     /// Dekodierte Node-Ereignisse: selfInfo, nodeAdvert, contact, contactsStart/End.
     var nodeEventStream: AsyncStream<DecodedFrame> { get }
+    /// Alle BLE-Frames (ein- und ausgehend) als Log-Einträge. DiagnosticsViewModel konsumiert diesen Stream.
+    var rxLogStream: AsyncStream<RxLogEntry> { get }
 
     func startScanning()
     func stopScanning()

--- a/MeshCoreMac/Services/MeshCoreBluetoothService.swift
+++ b/MeshCoreMac/Services/MeshCoreBluetoothService.swift
@@ -30,6 +30,8 @@ final class MeshCoreBluetoothService: NSObject, BluetoothServiceProtocol {
     private let frameContinuation: AsyncStream<Data>.Continuation
     let nodeEventStream: AsyncStream<DecodedFrame>
     private let nodeEventContinuation: AsyncStream<DecodedFrame>.Continuation
+    let rxLogStream: AsyncStream<RxLogEntry>
+    private let rxLogContinuation: AsyncStream<RxLogEntry>.Continuation
 
     // MARK: - CoreBluetooth
     private var centralManager: CBCentralManager!
@@ -53,6 +55,9 @@ final class MeshCoreBluetoothService: NSObject, BluetoothServiceProtocol {
         let (nodeStream, nodeCont) = AsyncStream<DecodedFrame>.makeStream()
         self.nodeEventStream = nodeStream
         self.nodeEventContinuation = nodeCont
+        let (logStream, logCont) = AsyncStream<RxLogEntry>.makeStream()
+        self.rxLogStream = logStream
+        self.rxLogContinuation = logCont
         super.init()
         self.centralManager = CBCentralManager(delegate: self, queue: .main)
     }
@@ -61,6 +66,7 @@ final class MeshCoreBluetoothService: NSObject, BluetoothServiceProtocol {
         reconnectTask?.cancel()
         frameContinuation.finish()
         nodeEventContinuation.finish()
+        rxLogContinuation.finish()
     }
 
     // MARK: - Public API
@@ -108,6 +114,13 @@ final class MeshCoreBluetoothService: NSObject, BluetoothServiceProtocol {
             throw BluetoothError.notConnected
         }
         peripheral.writeValue(data, for: characteristic, type: .withResponse)
+        rxLogContinuation.yield(RxLogEntry(
+            id: UUID(),
+            timestamp: Date(),
+            direction: .outgoing,
+            rawBytes: data,
+            decoded: nil
+        ))
     }
 
     // MARK: - Auto-Reconnect
@@ -258,8 +271,9 @@ extension MeshCoreBluetoothService: @preconcurrency CBPeripheralDelegate {
         guard error == nil, let value = characteristic.value else { return }
         frameContinuation.yield(value)
 
-        // Route decoded node events to nodeEventStream (ChatViewModel ignores these via break)
-        if let decoded = try? MeshCoreProtocolService.decodeFrame(value) {
+        let decoded = try? MeshCoreProtocolService.decodeFrame(value)
+
+        if let decoded {
             switch decoded {
             case .selfInfo, .nodeAdvert, .contact, .contactsStart, .contactsEnd:
                 nodeEventContinuation.yield(decoded)
@@ -267,6 +281,15 @@ extension MeshCoreBluetoothService: @preconcurrency CBPeripheralDelegate {
                 break
             }
         }
+
+        rxLogContinuation.yield(RxLogEntry(
+            id: UUID(),
+            timestamp: Date(),
+            direction: .incoming,
+            rawBytes: value,
+            decoded: decoded?.displayDescription
+                ?? value.first.map { "Unbekannt: 0x\(String(format: "%02X", $0))" }
+        ))
     }
 
     private func sendInitSequence() {

--- a/MeshCoreMac/Services/MeshCoreBluetoothService.swift
+++ b/MeshCoreMac/Services/MeshCoreBluetoothService.swift
@@ -275,7 +275,8 @@ extension MeshCoreBluetoothService: @preconcurrency CBPeripheralDelegate {
 
         if let decoded {
             switch decoded {
-            case .selfInfo, .nodeAdvert, .contact, .contactsStart, .contactsEnd:
+            case .selfInfo, .nodeAdvert, .contact, .contactsStart, .contactsEnd,
+                 .battAndStorage, .noiseFloor:
                 nodeEventContinuation.yield(decoded)
             case .newChannelMessage, .newDirectMessage, .messageAck:
                 break

--- a/MeshCoreMac/Services/MeshCoreProtocol.swift
+++ b/MeshCoreMac/Services/MeshCoreProtocol.swift
@@ -119,3 +119,33 @@ enum ProtocolError: Error, Equatable, Sendable {
     case invalidPayload(String)
     case messageTooLong(Int)
 }
+
+// MARK: - Display
+
+extension DecodedFrame {
+    var displayDescription: String {
+        switch self {
+        case .selfInfo(let nodeId, let lat, _, let firmware):
+            let pos = lat.map { String(format: "%.4f", $0) } ?? "-"
+            return "SELF_INFO node=\(nodeId) lat=\(pos) fw=\(firmware)"
+        case .newChannelMessage(let msg):
+            if case .channel(let idx) = msg.kind {
+                return "CH_MSG ch=\(idx) hops=\(msg.routing?.hops ?? 0) '\(msg.text.prefix(40))'"
+            }
+            return "CH_MSG '\(msg.text.prefix(40))'"
+        case .newDirectMessage(let msg):
+            return "DM from=\(msg.senderName) hops=\(msg.routing?.hops ?? 0) '\(msg.text.prefix(40))'"
+        case .messageAck(let id):
+            return "ACK id=\(id.prefix(8))"
+        case .nodeAdvert(let cid, let name, let lat, _):
+            let pos = lat.map { String(format: "%.4f", $0) } ?? "-"
+            return "ADVERT id=\(cid) name=\(name ?? "-") lat=\(pos)"
+        case .contact(let c):
+            return "CONTACT id=\(c.id) name=\(c.name) online=\(c.isOnline)"
+        case .contactsStart:
+            return "CONTACTS_START"
+        case .contactsEnd:
+            return "CONTACTS_END"
+        }
+    }
+}

--- a/MeshCoreMac/Services/MeshCoreProtocol.swift
+++ b/MeshCoreMac/Services/MeshCoreProtocol.swift
@@ -30,6 +30,7 @@ enum MeshCoreProtocol {
         case sendChannelTxtMsg  = 0x03  // CMD_SEND_CHANNEL_TXT_MSG
         case getContacts        = 0x04  // CMD_GET_CONTACTS
         case getDeviceTime      = 0x05  // CMD_GET_DEVICE_TIME
+        case tracePath          = 0x07  // CMD_TRACE_PATH — VERIFY: cmd byte unconfirmed
         case syncNextMessage    = 0x0A  // CMD_SYNC_NEXT_MESSAGE
         case getBattAndStorage  = 0x14  // CMD_GET_BATT_AND_STORAGE
         case deviceQuery        = 0x16  // CMD_DEVICE_QUERY (22)
@@ -109,6 +110,12 @@ enum DecodedFrame: Sendable, Equatable {
     case contactsStart
     /// Endsignal der GET_CONTACTS-Antwort (END_OF_CONTACTS 0x04).
     case contactsEnd
+    /// Batterie-Ladezustand und Speicherinfo (RESP_BATT_AND_STORAGE 0x0C).
+    /// Format: [battery_pct:1][storage_used_le32:4][storage_free_le32:4] — VERIFY
+    case battAndStorage(battery: Int, storageUsed: Int, storageFree: Int)
+    /// RF-Status (PUSH_STATUS_RESPONSE 0x87): RSSI und Noise Floor in dBm.
+    /// Format: [rssi_i8:1][noise_i8:1] — VERIFY
+    case noiseFloor(rssi: Int, noise: Int)
 }
 
 // MARK: - Fehler
@@ -146,6 +153,10 @@ extension DecodedFrame {
             return "CONTACTS_START"
         case .contactsEnd:
             return "CONTACTS_END"
+        case .battAndStorage(let batt, let used, let free):
+            return "BATT_STORAGE batt=\(batt)% used=\(used)B free=\(free)B"
+        case .noiseFloor(let rssi, let noise):
+            return "STATUS rssi=\(rssi)dBm noise=\(noise)dBm"
         }
     }
 }

--- a/MeshCoreMac/Services/MeshCoreProtocolService.swift
+++ b/MeshCoreMac/Services/MeshCoreProtocolService.swift
@@ -28,6 +28,24 @@ enum MeshCoreProtocolService {
         Data([MeshCoreProtocol.Command.getContacts.rawValue])
     }
 
+    /// Kodiert CMD_TRACE_PATH (0x07) mit 4-Byte Contact-ID-Präfix.
+    /// VERIFY: Byte 0x07 und Format gegen reale Firmware bestätigen.
+    static func encodeTracePath(contactId: String) -> Data {
+        var bytes: [UInt8] = [MeshCoreProtocol.Command.tracePath.rawValue]
+        let idBytes = stride(from: 0, to: min(contactId.count, 8), by: 2).compactMap {
+            let start = contactId.index(contactId.startIndex, offsetBy: $0)
+            let end = contactId.index(start, offsetBy: 2, limitedBy: contactId.endIndex) ?? contactId.endIndex
+            return UInt8(contactId[start..<end], radix: 16)
+        }
+        bytes.append(contentsOf: idBytes.prefix(4))
+        while bytes.count < 5 { bytes.append(0x00) }
+        return Data(bytes)
+    }
+
+    static func encodeBattAndStorage() -> Data {
+        Data([MeshCoreProtocol.Command.getBattAndStorage.rawValue])
+    }
+
     static func encodeSendTextMessage(
         text: String,
         channelIndex: UInt8,
@@ -70,7 +88,9 @@ enum MeshCoreProtocolService {
                 return try decodeContact(payload)
             case .endOfContacts:
                 return .contactsEnd
-            case .ok, .err, .currTime, .noMoreMessages, .battAndStorage:
+            case .battAndStorage:
+                return try decodeBattAndStorage(payload)
+            case .ok, .err, .currTime, .noMoreMessages:
                 throw ProtocolError.unknownCommand(commandByte)
             }
         }
@@ -81,7 +101,9 @@ enum MeshCoreProtocolService {
                 return try decodeMsgAck(payload)
             case .advert, .pathUpdated:
                 return try decodeNodeAdvertPush(payload)
-            case .msgWaiting, .rawData, .loginSuccess, .loginFail, .statusResponse:
+            case .statusResponse:
+                return try decodeStatusResponse(payload)
+            case .msgWaiting, .rawData, .loginSuccess, .loginFail:
                 throw ProtocolError.unknownCommand(commandByte)
             }
         }
@@ -235,5 +257,32 @@ enum MeshCoreProtocolService {
             | UInt32(bytes[offset + 2]) << 16
             | UInt32(bytes[offset + 3]) << 24
         return Float(bitPattern: bits)
+    }
+
+    /// Dekodiert RESP_BATT_AND_STORAGE (0x0C).
+    /// Format (VERIFY): [battery_pct:1][storage_used_le32:4][storage_free_le32:4]
+    private static func decodeBattAndStorage(_ payload: Data) throws -> DecodedFrame {
+        let bytes = Array(payload)
+        guard bytes.count >= 9 else {
+            throw ProtocolError.invalidPayload("BATT_AND_STORAGE zu kurz")
+        }
+        let battery = Int(bytes[0])
+        let used = Int(UInt32(bytes[1]) | UInt32(bytes[2]) << 8 |
+                       UInt32(bytes[3]) << 16 | UInt32(bytes[4]) << 24)
+        let free = Int(UInt32(bytes[5]) | UInt32(bytes[6]) << 8 |
+                       UInt32(bytes[7]) << 16 | UInt32(bytes[8]) << 24)
+        return .battAndStorage(battery: battery, storageUsed: used, storageFree: free)
+    }
+
+    /// Dekodiert PUSH_STATUS_RESPONSE (0x87).
+    /// Format (VERIFY): [rssi_signed:1][noise_signed:1]
+    private static func decodeStatusResponse(_ payload: Data) throws -> DecodedFrame {
+        let bytes = Array(payload)
+        guard bytes.count >= 2 else {
+            throw ProtocolError.invalidPayload("STATUS_RESPONSE zu kurz")
+        }
+        let rssi = Int(Int8(bitPattern: bytes[0]))
+        let noise = Int(Int8(bitPattern: bytes[1]))
+        return .noiseFloor(rssi: rssi, noise: noise)
     }
 }

--- a/MeshCoreMac/ViewModels/ChatViewModel.swift
+++ b/MeshCoreMac/ViewModels/ChatViewModel.swift
@@ -120,7 +120,8 @@ final class ChatViewModel {
                     )
                 }
 
-            case .selfInfo, .nodeAdvert, .contact, .contactsStart, .contactsEnd:
+            case .selfInfo, .nodeAdvert, .contact, .contactsStart, .contactsEnd,
+                 .battAndStorage, .noiseFloor:
                 break
             }
         } catch {

--- a/MeshCoreMac/ViewModels/ContactsViewModel.swift
+++ b/MeshCoreMac/ViewModels/ContactsViewModel.swift
@@ -85,7 +85,8 @@ final class ContactsViewModel {
                 collectingContacts = false
                 pendingContacts = []
             }
-        case .newChannelMessage, .newDirectMessage, .messageAck:
+        case .newChannelMessage, .newDirectMessage, .messageAck,
+             .battAndStorage, .noiseFloor:
             break
         }
     }

--- a/MeshCoreMac/ViewModels/DiagnosticsViewModel.swift
+++ b/MeshCoreMac/ViewModels/DiagnosticsViewModel.swift
@@ -1,0 +1,103 @@
+// MeshCoreMac/ViewModels/DiagnosticsViewModel.swift
+import Foundation
+import Observation
+
+enum CLIError: Error, LocalizedError {
+    case invalidHex(String)
+    var errorDescription: String? {
+        switch self {
+        case .invalidHex(let s): return "Ungültige Hex-Eingabe: '\(s)'"
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class DiagnosticsViewModel {
+
+    private(set) var logEntries: [RxLogEntry] = []
+    private(set) var batteryPercent: Int? = nil
+    private(set) var storageUsed: Int? = nil
+    private(set) var storageFree: Int? = nil
+    private(set) var rssi: Int? = nil
+    private(set) var noiseFloor: Int? = nil
+
+    var cliInput: String = ""
+    private(set) var cliHistory: [String] = []
+
+    private let bluetoothService: any BluetoothServiceProtocol
+    nonisolated(unsafe) private var listenerTask: Task<Void, Never>?
+    private var started = false
+
+    static let maxEntries = 200
+
+    init(bluetoothService: any BluetoothServiceProtocol) {
+        self.bluetoothService = bluetoothService
+    }
+
+    func start() async {
+        guard !started else { return }
+        started = true
+        startListening()
+    }
+
+    func sendCLICommand() async throws {
+        let trimmed = cliInput.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        let tokens = trimmed.split(separator: " ").map(String.init)
+        var bytes: [UInt8] = []
+        for token in tokens {
+            guard let byte = UInt8(token, radix: 16) else {
+                throw CLIError.invalidHex(token)
+            }
+            bytes.append(byte)
+        }
+        try bluetoothService.send(Data(bytes))
+        cliHistory.insert(trimmed, at: 0)
+        if cliHistory.count > 50 { cliHistory.removeLast() }
+        cliInput = ""
+    }
+
+    func requestNodeStatus() async throws {
+        try bluetoothService.send(MeshCoreProtocolService.encodeBattAndStorage())
+    }
+
+    func clearLog() {
+        logEntries = []
+    }
+
+    private func startListening() {
+        listenerTask?.cancel()
+        listenerTask = Task {
+            for await entry in self.bluetoothService.rxLogStream {
+                guard !Task.isCancelled else { break }
+                self.handleEntry(entry)
+            }
+        }
+    }
+
+    private func handleEntry(_ entry: RxLogEntry) {
+        if logEntries.count >= Self.maxEntries {
+            logEntries.removeFirst()
+        }
+        logEntries.append(entry)
+
+        guard entry.direction == .incoming,
+              let decoded = try? MeshCoreProtocolService.decodeFrame(entry.rawBytes) else { return }
+        switch decoded {
+        case .battAndStorage(let batt, let used, let free):
+            batteryPercent = batt
+            storageUsed = used
+            storageFree = free
+        case .noiseFloor(let r, let n):
+            rssi = r
+            noiseFloor = n
+        default:
+            break
+        }
+    }
+
+    deinit {
+        listenerTask?.cancel()
+    }
+}

--- a/MeshCoreMac/Views/Diagnostics/CLIView.swift
+++ b/MeshCoreMac/Views/Diagnostics/CLIView.swift
@@ -2,7 +2,7 @@
 import SwiftUI
 
 struct CLIView: View {
-    let diagnosticsVM: DiagnosticsViewModel
+    @Bindable var diagnosticsVM: DiagnosticsViewModel
     @State private var errorMessage: String? = nil
 
     private let quickCommands: [(label: String, hex: String, description: String)] = [
@@ -47,12 +47,8 @@ struct CLIView: View {
             Divider()
 
             HStack(alignment: .center, spacing: 8) {
-                let inputBinding = Binding(
-                    get: { diagnosticsVM.cliInput },
-                    set: { diagnosticsVM.cliInput = $0 }
-                )
                 TextField("Hex-Bytes eingeben (z.B. 04  oder  07 A1 B2 C3 D4)",
-                          text: inputBinding)
+                          text: $diagnosticsVM.cliInput)
                     .font(.system(.body, design: .monospaced))
                     .textFieldStyle(.plain)
                     .padding(.horizontal, 8)

--- a/MeshCoreMac/Views/Diagnostics/CLIView.swift
+++ b/MeshCoreMac/Views/Diagnostics/CLIView.swift
@@ -1,0 +1,105 @@
+// MeshCoreMac/Views/Diagnostics/CLIView.swift
+import SwiftUI
+
+struct CLIView: View {
+    let diagnosticsVM: DiagnosticsViewModel
+    @State private var errorMessage: String? = nil
+
+    private let quickCommands: [(label: String, hex: String, description: String)] = [
+        ("GET_CONTACTS", "04", "Kontaktliste abrufen"),
+        ("DEVICE_QUERY", "16", "Node-Info abfragen"),
+        ("BATT_STORAGE", "14", "Batterie & Speicher abfragen"),
+        ("APP_START", "01", "App-Start senden"),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Schnellbefehle")
+                .font(.headline)
+                .padding(.horizontal, 12)
+                .padding(.top, 12)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(quickCommands, id: \.hex) { cmd in
+                        Button {
+                            diagnosticsVM.cliInput = cmd.hex
+                        } label: {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(cmd.label)
+                                    .font(.caption)
+                                    .fontWeight(.medium)
+                                Text("0x\(cmd.hex.uppercased())")
+                                    .font(.system(.caption2, design: .monospaced))
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(Color.accentColor.opacity(0.1), in: RoundedRectangle(cornerRadius: 6))
+                        }
+                        .buttonStyle(.plain)
+                        .help(cmd.description)
+                    }
+                }
+                .padding(.horizontal, 12)
+            }
+
+            Divider()
+
+            HStack(alignment: .center, spacing: 8) {
+                let inputBinding = Binding(
+                    get: { diagnosticsVM.cliInput },
+                    set: { diagnosticsVM.cliInput = $0 }
+                )
+                TextField("Hex-Bytes eingeben (z.B. 04  oder  07 A1 B2 C3 D4)",
+                          text: inputBinding)
+                    .font(.system(.body, design: .monospaced))
+                    .textFieldStyle(.plain)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
+                    .onSubmit { trySend() }
+
+                Button("Senden") { trySend() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(diagnosticsVM.cliInput.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding(.horizontal, 12)
+
+            if let err = errorMessage {
+                Text(err)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 12)
+            }
+
+            if !diagnosticsVM.cliHistory.isEmpty {
+                Divider()
+                Text("Verlauf")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                List(diagnosticsVM.cliHistory, id: \.self) { cmd in
+                    Text(cmd)
+                        .font(.system(.caption, design: .monospaced))
+                        .onTapGesture { diagnosticsVM.cliInput = cmd }
+                }
+                .listStyle(.plain)
+                .frame(maxHeight: 150)
+            }
+
+            Spacer()
+        }
+    }
+
+    private func trySend() {
+        Task {
+            do {
+                errorMessage = nil
+                try await diagnosticsVM.sendCLICommand()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/MeshCoreMac/Views/Diagnostics/DiagnosticsView.swift
+++ b/MeshCoreMac/Views/Diagnostics/DiagnosticsView.swift
@@ -1,0 +1,19 @@
+// MeshCoreMac/Views/Diagnostics/DiagnosticsView.swift
+import SwiftUI
+
+struct DiagnosticsView: View {
+    let diagnosticsVM: DiagnosticsViewModel
+
+    var body: some View {
+        TabView {
+            RxLogView(diagnosticsVM: diagnosticsVM)
+                .tabItem { Label("RX Log", systemImage: "list.bullet.rectangle") }
+            CLIView(diagnosticsVM: diagnosticsVM)
+                .tabItem { Label("CLI", systemImage: "terminal") }
+            NodeStatusView(diagnosticsVM: diagnosticsVM)
+                .tabItem { Label("Status", systemImage: "antenna.radiowaves.left.and.right") }
+        }
+        .navigationTitle("Diagnose")
+        .frame(minWidth: 600, minHeight: 450)
+    }
+}

--- a/MeshCoreMac/Views/Diagnostics/NodeStatusView.swift
+++ b/MeshCoreMac/Views/Diagnostics/NodeStatusView.swift
@@ -1,0 +1,59 @@
+// MeshCoreMac/Views/Diagnostics/NodeStatusView.swift
+import SwiftUI
+
+struct NodeStatusView: View {
+    let diagnosticsVM: DiagnosticsViewModel
+
+    var body: some View {
+        Form {
+            Section("Batterie & Speicher") {
+                if let batt = diagnosticsVM.batteryPercent {
+                    LabeledContent("Batterie") {
+                        HStack {
+                            ProgressView(value: Double(batt), total: 100)
+                                .frame(width: 80)
+                            Text("\(batt)%")
+                                .monospacedDigit()
+                        }
+                    }
+                } else {
+                    LabeledContent("Batterie", value: "–")
+                }
+
+                if let used = diagnosticsVM.storageUsed,
+                   let free = diagnosticsVM.storageFree {
+                    LabeledContent("Belegt", value: formatBytes(used))
+                    LabeledContent("Frei", value: formatBytes(free))
+                } else {
+                    LabeledContent("Speicher", value: "–")
+                }
+            }
+
+            Section("RF-Diagnose") {
+                if let rssi = diagnosticsVM.rssi {
+                    LabeledContent("RSSI", value: "\(rssi) dBm")
+                } else {
+                    LabeledContent("RSSI", value: "–")
+                }
+                if let noise = diagnosticsVM.noiseFloor {
+                    LabeledContent("Noise Floor", value: "\(noise) dBm")
+                } else {
+                    LabeledContent("Noise Floor", value: "–")
+                }
+            }
+
+            Section {
+                Button("Status abfragen") {
+                    Task { try? await diagnosticsVM.requestNodeStatus() }
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func formatBytes(_ bytes: Int) -> String {
+        if bytes >= 1_048_576 { return String(format: "%.1f MB", Double(bytes) / 1_048_576) }
+        if bytes >= 1024 { return String(format: "%.1f KB", Double(bytes) / 1024) }
+        return "\(bytes) B"
+    }
+}

--- a/MeshCoreMac/Views/Diagnostics/RxLogView.swift
+++ b/MeshCoreMac/Views/Diagnostics/RxLogView.swift
@@ -1,0 +1,81 @@
+// MeshCoreMac/Views/Diagnostics/RxLogView.swift
+import SwiftUI
+
+struct RxLogView: View {
+    let diagnosticsVM: DiagnosticsViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("RX Log")
+                    .font(.headline)
+                Spacer()
+                Text("\(diagnosticsVM.logEntries.count) Einträge")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Button("Leeren") { diagnosticsVM.clearLog() }
+                    .buttonStyle(.borderless)
+                    .font(.caption)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(diagnosticsVM.logEntries) { entry in
+                            RxLogRowView(entry: entry)
+                                .id(entry.id)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .onChange(of: diagnosticsVM.logEntries.count) { _, _ in
+                    if let last = diagnosticsVM.logEntries.last {
+                        withAnimation(.easeOut(duration: 0.15)) {
+                            proxy.scrollTo(last.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct RxLogRowView: View {
+    let entry: RxLogEntry
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f
+    }()
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(entry.direction.rawValue)
+                .foregroundStyle(entry.direction == .incoming ? Color.blue : Color.orange)
+                .font(.system(.caption, design: .monospaced))
+                .frame(width: 12)
+            Text(Self.timeFormatter.string(from: entry.timestamp))
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 90, alignment: .leading)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(entry.hexString)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.primary)
+                if let decoded = entry.decoded {
+                    Text(decoded)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 2)
+    }
+}

--- a/MeshCoreMac/Views/MainWindow/MainWindowView.swift
+++ b/MeshCoreMac/Views/MainWindow/MainWindowView.swift
@@ -6,6 +6,7 @@ struct MainWindowView: View {
 
     @State private var dismissedError: String? = nil
     @State private var showingMap = false
+    @State private var showingDiagnostics = false
 
     var body: some View {
         Group {
@@ -43,6 +44,16 @@ struct MainWindowView: View {
                     }
             }
         }
+        .sheet(isPresented: $showingDiagnostics) {
+            NavigationStack {
+                DiagnosticsView(diagnosticsVM: container.diagnosticsViewModel)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Schließen") { showingDiagnostics = false }
+                        }
+                    }
+            }
+        }
     }
 
     private var messengerView: some View {
@@ -76,6 +87,14 @@ struct MainWindowView: View {
                     Label("Karte", systemImage: "map")
                 }
                 .help("Karte aller bekannten Nodes anzeigen")
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showingDiagnostics = true
+                } label: {
+                    Label("Diagnose", systemImage: "waveform.path.ecg")
+                }
+                .help("Diagnose-Fenster: RX Log, CLI, Node Status")
             }
         }
     }

--- a/MeshCoreMacTests/Services/MeshCoreProtocolServiceTests.swift
+++ b/MeshCoreMacTests/Services/MeshCoreProtocolServiceTests.swift
@@ -153,4 +153,41 @@ final class MeshCoreProtocolServiceTests: XCTestCase {
         let decoded = try MeshCoreProtocolService.decodeFrame(frame)
         XCTAssertEqual(decoded, .contactsStart)
     }
+
+    func testDecodeBattAndStorage_valid() throws {
+        // battery=75%, storageUsed=1024B, storageFree=8192B
+        var frame = Data([MeshCoreProtocol.Response.battAndStorage.rawValue])
+        frame.append(75)                                          // battery percent
+        frame.append(contentsOf: [0x00, 0x04, 0x00, 0x00])       // 1024 LE uint32
+        frame.append(contentsOf: [0x00, 0x20, 0x00, 0x00])       // 8192 LE uint32
+        let decoded = try MeshCoreProtocolService.decodeFrame(frame)
+        guard case .battAndStorage(let batt, let used, let free) = decoded else {
+            XCTFail("Expected .battAndStorage"); return
+        }
+        XCTAssertEqual(batt, 75)
+        XCTAssertEqual(used, 1024)
+        XCTAssertEqual(free, 8192)
+    }
+
+    func testDecodeNoiseFloor_valid() throws {
+        var frame = Data([MeshCoreProtocol.Push.statusResponse.rawValue])
+        frame.append(UInt8(bitPattern: Int8(-80)))
+        frame.append(UInt8(bitPattern: Int8(-110)))
+        let decoded = try MeshCoreProtocolService.decodeFrame(frame)
+        guard case .noiseFloor(let rssi, let noise) = decoded else {
+            XCTFail("Expected .noiseFloor"); return
+        }
+        XCTAssertEqual(rssi, -80)
+        XCTAssertEqual(noise, -110)
+    }
+
+    func testEncodeTracePath_producesCorrectBytes() {
+        let data = MeshCoreProtocolService.encodeTracePath(contactId: "a1b2c3d4")
+        XCTAssertEqual(data[0], MeshCoreProtocol.Command.tracePath.rawValue)
+        XCTAssertEqual(data.count, 5)
+        XCTAssertEqual(data[1], 0xa1)
+        XCTAssertEqual(data[2], 0xb2)
+        XCTAssertEqual(data[3], 0xc3)
+        XCTAssertEqual(data[4], 0xd4)
+    }
 }

--- a/MeshCoreMacTests/Services/MockBluetoothService.swift
+++ b/MeshCoreMacTests/Services/MockBluetoothService.swift
@@ -17,6 +17,8 @@ final class MockBluetoothService: BluetoothServiceProtocol {
     private let frameContinuation: AsyncStream<Data>.Continuation
     let nodeEventStream: AsyncStream<DecodedFrame>
     private let nodeEventContinuation: AsyncStream<DecodedFrame>.Continuation
+    let rxLogStream: AsyncStream<RxLogEntry>
+    private let rxLogContinuation: AsyncStream<RxLogEntry>.Continuation
 
     var sentFrames: [Data] = []
     var scanStarted = false
@@ -29,6 +31,9 @@ final class MockBluetoothService: BluetoothServiceProtocol {
         let (nodeStream, nodeCont) = AsyncStream<DecodedFrame>.makeStream()
         self.nodeEventStream = nodeStream
         self.nodeEventContinuation = nodeCont
+        let (logStream, logCont) = AsyncStream<RxLogEntry>.makeStream()
+        self.rxLogStream = logStream
+        self.rxLogContinuation = logCont
     }
 
     func startScanning() { scanStarted = true }
@@ -56,6 +61,10 @@ final class MockBluetoothService: BluetoothServiceProtocol {
         nodeEventContinuation.yield(frame)
     }
 
+    func simulateRxLogEntry(_ entry: RxLogEntry) {
+        rxLogContinuation.yield(entry)
+    }
+
     func simulateDisconnect() {
         connectionState = .failed(peripheralName: "Mock-Node", error: "Verbindung verloren")
     }
@@ -67,5 +76,6 @@ final class MockBluetoothService: BluetoothServiceProtocol {
     deinit {
         frameContinuation.finish()
         nodeEventContinuation.finish()
+        rxLogContinuation.finish()
     }
 }

--- a/MeshCoreMacTests/ViewModels/DiagnosticsViewModelTests.swift
+++ b/MeshCoreMacTests/ViewModels/DiagnosticsViewModelTests.swift
@@ -1,0 +1,129 @@
+// MeshCoreMacTests/ViewModels/DiagnosticsViewModelTests.swift
+import XCTest
+@testable import MeshCoreMac
+
+@MainActor
+final class DiagnosticsViewModelTests: XCTestCase {
+
+    var mockBluetooth: MockBluetoothService!
+    var vm: DiagnosticsViewModel!
+
+    override func setUp() async throws {
+        mockBluetooth = MockBluetoothService()
+        vm = DiagnosticsViewModel(bluetoothService: mockBluetooth)
+        await vm.start()
+    }
+
+    override func tearDown() async throws {
+        vm = nil
+        mockBluetooth = nil
+    }
+
+    func testLogEntries_appendOnIncomingEntry() async throws {
+        let entry = RxLogEntry(id: UUID(), timestamp: Date(),
+                               direction: .incoming, rawBytes: Data([0x04]), decoded: "GET_CONTACTS")
+        mockBluetooth.simulateRxLogEntry(entry)
+        try await waitUntil { !self.vm.logEntries.isEmpty }
+        XCTAssertEqual(vm.logEntries.count, 1)
+        XCTAssertEqual(vm.logEntries[0].decoded, "GET_CONTACTS")
+    }
+
+    func testLogEntries_cappedAt200() async throws {
+        for i in 0..<210 {
+            let entry = RxLogEntry(id: UUID(), timestamp: Date(),
+                                   direction: .incoming,
+                                   rawBytes: Data([UInt8(i % 256)]),
+                                   decoded: "Entry \(i)")
+            mockBluetooth.simulateRxLogEntry(entry)
+        }
+        try await waitUntil { self.vm.logEntries.count >= 200 }
+        try await Task.sleep(for: .milliseconds(30))
+        XCTAssertLessThanOrEqual(vm.logEntries.count, DiagnosticsViewModel.maxEntries)
+    }
+
+    func testSendCLICommand_validHex_sendsBytes() async throws {
+        vm.cliInput = "04"
+        try await vm.sendCLICommand()
+        XCTAssertEqual(mockBluetooth.sentFrames.count, 1)
+        XCTAssertEqual(mockBluetooth.sentFrames[0], Data([0x04]))
+    }
+
+    func testSendCLICommand_multiByteHex_sendsCorrectBytes() async throws {
+        vm.cliInput = "07 A1 B2 C3"
+        try await vm.sendCLICommand()
+        XCTAssertEqual(mockBluetooth.sentFrames[0], Data([0x07, 0xA1, 0xB2, 0xC3]))
+    }
+
+    func testSendCLICommand_invalidHex_throws() async throws {
+        vm.cliInput = "ZZ"
+        do {
+            try await vm.sendCLICommand()
+            XCTFail("Hätte CLIError werfen sollen")
+        } catch CLIError.invalidHex(let token) {
+            XCTAssertEqual(token, "ZZ")
+        }
+    }
+
+    func testSendCLICommand_addsToHistory() async throws {
+        vm.cliInput = "04"
+        try await vm.sendCLICommand()
+        XCTAssertEqual(vm.cliHistory.first, "04")
+        XCTAssertEqual(vm.cliInput, "")
+    }
+
+    func testHandleEntry_battAndStorage_updatesBatteryPercent() async throws {
+        var frame = Data([MeshCoreProtocol.Response.battAndStorage.rawValue])
+        frame.append(80)
+        frame.append(contentsOf: [0x00, 0x10, 0x00, 0x00])
+        frame.append(contentsOf: [0x00, 0x40, 0x00, 0x00])
+        let entry = RxLogEntry(id: UUID(), timestamp: Date(),
+                               direction: .incoming, rawBytes: frame, decoded: nil)
+        mockBluetooth.simulateRxLogEntry(entry)
+        try await waitUntil { self.vm.batteryPercent != nil }
+        XCTAssertEqual(vm.batteryPercent, 80)
+        XCTAssertEqual(vm.storageUsed, 4096)
+        XCTAssertEqual(vm.storageFree, 16384)
+    }
+
+    func testHandleEntry_noiseFloor_updatesNoiseFloor() async throws {
+        var frame = Data([MeshCoreProtocol.Push.statusResponse.rawValue])
+        frame.append(UInt8(bitPattern: Int8(-85)))
+        frame.append(UInt8(bitPattern: Int8(-115)))
+        let entry = RxLogEntry(id: UUID(), timestamp: Date(),
+                               direction: .incoming, rawBytes: frame, decoded: nil)
+        mockBluetooth.simulateRxLogEntry(entry)
+        try await waitUntil { self.vm.noiseFloor != nil }
+        XCTAssertEqual(vm.rssi, -85)
+        XCTAssertEqual(vm.noiseFloor, -115)
+    }
+
+    func testRequestNodeStatus_sendsBattAndStorageCommand() async throws {
+        try await vm.requestNodeStatus()
+        XCTAssertEqual(mockBluetooth.sentFrames.count, 1)
+        XCTAssertEqual(mockBluetooth.sentFrames[0][0],
+                       MeshCoreProtocol.Command.getBattAndStorage.rawValue)
+    }
+
+    func testStart_calledTwice_isNoOp() async throws {
+        let mockB = MockBluetoothService()
+        let vm2 = DiagnosticsViewModel(bluetoothService: mockB)
+        await vm2.start()
+        await vm2.start()
+        let entry = RxLogEntry(id: UUID(), timestamp: Date(),
+                               direction: .incoming, rawBytes: Data([0x05]), decoded: "SELF_INFO")
+        mockB.simulateRxLogEntry(entry)
+        try await waitUntil { !vm2.logEntries.isEmpty }
+        XCTAssertEqual(vm2.logEntries.count, 1)
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 1.0,
+        condition: @escaping () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            guard Date() < deadline else { XCTFail("Timeout"); return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Neuer `rxLogStream: AsyncStream<RxLogEntry>` in `BluetoothServiceProtocol` loggt alle BLE-Frames (ein- und ausgehend)
- `DiagnosticsViewModel` konsumiert diesen Stream für Live-RX-Log, re-dekodiert Batterie/Speicher- und RF-Status-Frames
- Neue `DecodedFrame`-Cases `.battAndStorage` und `.noiseFloor` mit Encodern/Decodern in `MeshCoreProtocolService`
- `DiagnosticsView` (TabView) mit RX-Log-Tab, CLI-Tab (Hex-Befehlseingabe + Schnellbefehle) und Status-Tab
- Diagnose-Fenster über neuen Toolbar-Button in `MainWindowView` erreichbar

## Test Plan

- [ ] 59/59 Unit-Tests grün (`xcodebuild test`)
- [ ] Diagnose-Toolbar-Button öffnet Sheet mit 3 Tabs
- [ ] RX-Log scrollt automatisch bei neuen Frames
- [ ] CLI-Tab: Hex-Befehl senden, Fehlermeldung bei ungültigem Hex
- [ ] Status-Tab: Batterie/Speicher erscheinen nach `RESP_BATT_AND_STORAGE (0x0C)`
- [ ] Noise Floor erscheint nach `PUSH_STATUS_RESPONSE (0x87)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)